### PR TITLE
Return v5 servers while constructing the matrix

### DIFF
--- a/KubernetesExternalClients/python/client.py
+++ b/KubernetesExternalClients/python/client.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
 
     client = hazelcast.HazelcastClient(
         cluster_members=["<EXTERNAL-IP>"],
-        use_public_ip=True
+        use_public_ip=True,
     )
 
     my_map = client.get_map("map_for_python").blocking()
@@ -30,4 +30,3 @@ if __name__ == "__main__":
         raise Exception("Connection failed, check your configuration.")
 
     client.shutdown()
-

--- a/KubernetesInternalClients/python/client.py
+++ b/KubernetesInternalClients/python/client.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     if my_map.get("key") == "value":
         print("Successful connection!")
         print("Starting to fill the map with random entries.")
-        
+
         while True:
             random_key = random.randint(1, 100000)
             try:
@@ -31,4 +31,3 @@ if __name__ == "__main__":
     else:
         client.shutdown()
         raise Exception("Connection failed, check your configuration.")
-

--- a/get_server_matrix.py
+++ b/get_server_matrix.py
@@ -20,7 +20,7 @@ def parse_args() -> argparse.Namespace:
 
 if __name__ == "__main__":
     args = parse_args()
-    filters: List[ReleaseFilter] = [MajorVersionFilter([4])]
+    filters: List[ReleaseFilter] = [MajorVersionFilter([4, 5])]
     server_release_parser = ServerReleaseParser(filters)
     releases = server_release_parser.get_all_releases()
     latest_patch_releases = get_latest_patch_releases(releases)


### PR DESCRIPTION
With this change, we will also include v5 servers in the client
compatibility tests.

The change simply adds a v5 server release filter and introduces
an extra logic to parse another file to get sources, since the
5.x server releases will be put into a different file.