### PR TITLE
Nodejs new release flow api-929

### DIFF
--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -217,14 +217,26 @@ jobs:
       with:
         repository: hazelcast/hazelcast-nodejs-client
         path: KubernetesExternalClients/nodejs/clientSourceCode
-        ref: ${{ github.event.inputs.nodejs_run }}
-        
+        ref: master
+
+    - name: Install dependencies
+      run: npm install
+      working-directory: KubernetesExternalClients/nodejs/clientSourceCode
+
+    - name: Download and prepare release pack from branch ${{ github.event.inputs.nodejs_run }}
+      run: |
+        node scripts/download-release-candidate.js -b ${{ github.event.inputs.nodejs_run }} -u github_actions -p ${{ secrets.GITHUB_TOKEN }} -o release-candidate.zip
+        unzip release-candidate.zip
+        sha256sum --check release-pack.sha256
+        tar xvzf hazelcast-client-*.tgz
+        rm -rf lib
+        mv package/lib .
+      working-directory: KubernetesExternalClients/nodejs/clientSourceCode
+
     - name: Run test
       run: |
         cp KubernetesExternalClients/nodejs/client.js KubernetesExternalClients/nodejs/clientSourceCode/
         cd KubernetesExternalClients/nodejs/clientSourceCode
-        npm install
-        npm run compile
         sed -i "s/<EXTERNAL-IP>/'${{ steps.read_ip.outputs.value }}'/g" client.js
         node client.js &> output.txt && tail -n 20 output.txt &> last20lines.txt
         cat last20lines.txt

--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -91,20 +91,28 @@ jobs:
    steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
+
       - name: Checkout the client repo
         uses: actions/checkout@v2
         with:
           repository: hazelcast/hazelcast-nodejs-client
           path: KubernetesInternalClients/nodejs/clientSourceCode
-          ref: ${{ github.event.inputs.nodejs_run }}
-          
-      - name: Build client project
+          ref: master
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: KubernetesInternalClients/nodejs/clientSourceCode
+
+      - name: Download and prepare release pack from branch ${{ github.event.inputs.nodejs_run }}
         run: |
-            cd KubernetesInternalClients/nodejs/clientSourceCode
-            npm install
-            npm run compile
-            
+          node scripts/download-release-candidate.js -b ${{ github.event.inputs.nodejs_run }} -u github_actions -p ${{ secrets.GITHUB_TOKEN }} -o release-candidate.zip
+          unzip release-candidate.zip
+          sha256sum --check release-pack.sha256
+          tar xvzf hazelcast-client-*.tgz
+          rm -rf lib
+          mv package/lib .
+        working-directory: KubernetesInternalClients/nodejs/clientSourceCode
+
       - name: Build client application
         run: |-
           docker build -t hazelcast-nodejs-client:test KubernetesInternalClients/nodejs

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -62,10 +62,19 @@ jobs:
           repository: hazelcast/hazelcast-nodejs-client
           path: client
           ref: ${{ github.event.inputs.branch_name }}
-      - name: Install dependencies and compile client
+      - name: Install dependencies
+        run: npm install
+        working-directory: client
+      - name: Download and prepare the release pack
         run: |
-          npm install
-          npm run compile
+            node scripts/download-release-candidate.js -b ${{ github.event.inputs.branch_name }} -u github_actions -p $GH_PAT -o release-candidate.zip
+            unzip release-candidate.zip
+            sha256sum --check release-pack.sha256
+            tar xvzf hazelcast-client-*.tgz
+            rm -rf lib
+            mv package/lib .
+        env:
+          GH_PAT: ${{ secrets.GITHUB_TOKEN }}
         working-directory: client
       - name: Install test dependencies
         run: |

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -61,14 +61,12 @@ jobs:
         working-directory: master
       - name: Download and prepare the release pack
         run: |
-          node scripts/download-release-candidate.js -b ${{ github.event.inputs.branch_name }} -u github_actions -p $GH_PAT -o release-candidate.zip
+          node scripts/download-release-candidate.js -b ${{ github.event.inputs.branch_name }} -u github_actions -p ${{ secrets.GITHUB_TOKEN }} -o release-candidate.zip
           unzip release-candidate.zip
           sha256sum --check release-pack.sha256
           tar xvzf hazelcast-client-*.tgz
           rm -rf lib
           mv package/lib .
-        env:
-          GH_PAT: ${{ secrets.GITHUB_TOKEN }}
         working-directory: master
       - name: Start RC
         env:

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -56,47 +56,31 @@ jobs:
           repository: hazelcast/hazelcast-nodejs-client
           path: master
           ref: master
-      - name: Checkout to ${{ github.event.inputs.branch_name }}
-        uses: actions/checkout@v2
-        with:
-          repository: hazelcast/hazelcast-nodejs-client
-          path: client
-          ref: ${{ github.event.inputs.branch_name }}
       - name: Install dependencies
         run: npm install
-        working-directory: client
+        working-directory: master
       - name: Download and prepare the release pack
         run: |
-            node scripts/download-release-candidate.js -b ${{ github.event.inputs.branch_name }} -u github_actions -p $GH_PAT -o release-candidate.zip
-            unzip release-candidate.zip
-            sha256sum --check release-pack.sha256
-            tar xvzf hazelcast-client-*.tgz
-            rm -rf lib
-            mv package/lib .
+          node scripts/download-release-candidate.js -b ${{ github.event.inputs.branch_name }} -u github_actions -p $GH_PAT -o release-candidate.zip
+          unzip release-candidate.zip
+          sha256sum --check release-pack.sha256
+          tar xvzf hazelcast-client-*.tgz
+          rm -rf lib
+          mv package/lib .
         env:
           GH_PAT: ${{ secrets.GITHUB_TOKEN }}
-        working-directory: client
-      - name: Install test dependencies
-        run: |
-          npm install
         working-directory: master
-      - name: Copy client code into master
-        run: |
-          rm -rf $GITHUB_WORKSPACE/master/lib
-          rm $GITHUB_WORKSPACE/master/package.json
-          cp -a $GITHUB_WORKSPACE/client/lib $GITHUB_WORKSPACE/master/lib
-          cp -a $GITHUB_WORKSPACE/client/package.json $GITHUB_WORKSPACE/master/package.json
       - name: Start RC
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.kind }} --use-simple-server
       - name: Run non-enterprise tests
         if: ${{ matrix.kind == 'os' }}
-        run: node node_modules/mocha/bin/mocha --recursive test
+        run: npm run test
         working-directory: master
       - name: Run all tests
         if: ${{ matrix.kind == 'enterprise' }}
-        run: node node_modules/mocha/bin/mocha --recursive test/
+        run: npm run test
         working-directory: master
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}


### PR DESCRIPTION
Nodejs client repo counterpart: https://github.com/hazelcast/hazelcast-nodejs-client/pull/1092


Also, soak tests will be run via:

1. Downloading release pack using the same nodejs script used here.
2. Extracting lib and using that lib folder. 


**NOTE: This pr may not be necessary, if we decide not to run any test after packing. In that case I will close this pr.**