### PR TITLE
Use non simple server for nodejs client in server compatibility test

### DIFF
--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -286,7 +286,7 @@ jobs:
       - name: Start RC
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-        run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.server_kind }} --use-simple-server
+        run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.server_kind }}
       - name: Run non-enterprise tests
         if: ${{ matrix.server_kind == 'os' }}
         run: node node_modules/mocha/bin/mocha --recursive test/integration/backward_compatible


### PR DESCRIPTION
Node.js client uses parallel test which won't work with a simple server.