### PR TITLE
Use pytest as the test runner for Python client tests

### DIFF
--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -77,9 +77,9 @@ jobs:
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.kind }} --use-simple-server
       - name: Run non-enterprise tests
         if: ${{ matrix.kind == 'os' }}
-        run: nosetests -v tests/integration/backward_compatible -A 'not enterprise'
+        run: pytest -m 'not enterprise' tests/integration/backward_compatible
         working-directory: master
       - name: Run all tests
         if: ${{ matrix.kind == 'enterprise' }}
-        run: nosetests -v tests/integration/backward_compatible
+        run: pytest tests/integration/backward_compatible
         working-directory: master

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -182,11 +182,11 @@ jobs:
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.server_kind }} --use-simple-server
       - name: Run non-enterprise tests
         if: ${{ matrix.server_kind == 'os' }}
-        run: nosetests -v tests/integration/backward_compatible -A 'not enterprise'
+        run: pytest -m 'not enterprise' tests/integration/backward_compatible
         working-directory: master
       - name: Run all tests
         if: ${{ matrix.server_kind == 'enterprise' }}
-        run: nosetests -v tests/integration/backward_compatible
+        run: pytest tests/integration/backward_compatible
         working-directory: master
   setup_nodejs_client_matrix:
     name: Setup the Node.js client test matrix


### PR DESCRIPTION
After dropping support for Python2, the nosetest dependency is replaced
with pytest.

This PR updates the test runners with the new dependency.