### PR TITLE
Revert Node.js version to 14

### DIFF
--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -199,7 +199,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 10.4
+        node-version: 14
         
     - name: Checkout to scripts
       uses: actions/checkout@v2

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 10.4
+          node-version: 14
       - name: Setup Java
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -222,7 +222,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 10.4
+          node-version: 14
       - name: Setup Java
         uses: actions/setup-java@v1
         with:

--- a/KubernetesInternalClients/nodejs/Dockerfile
+++ b/KubernetesInternalClients/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.4
+FROM node:14
 ADD clientSourceCode/lib /lib
 ADD clientSourceCode/node_modules /node_modules
 ADD clientSourceCode/package.json .


### PR DESCRIPTION
This is a required change, as in Node.js 10.4, the tests were failing
due to client not being able to close connections.

The client was relying on the fact that writes to an already closed
socket would throw an error and the client would be able to close the
that connection, but that is not happening on Node.js 10.4.

Looking at the recent changes done by Serkan on the Node.js client,
it seems it is possible to work around that problem but that requires
a change in the client code, and we cannot do that for already
released clients.

So, we have to revert the Node.js version back and look for long-term
solutions once Serkan is back.