### PR TITLE
Run only backward compatible tests for Node.js backward compatibility…

### DIFF
--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -87,11 +87,11 @@ jobs:
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.kind }}
       - name: Run non-enterprise tests
         if: ${{ matrix.kind == 'os' }}
-        run: node node_modules/mocha/bin/mocha --recursive test
+        run: node node_modules/mocha/bin/mocha --recursive test/integration/backward_compatible
         working-directory: master
       - name: Run all tests
         if: ${{ matrix.kind == 'enterprise' }}
-        run: node node_modules/mocha/bin/mocha --recursive test/
+        run: node node_modules/mocha/bin/mocha --recursive test/integration/backward_compatible
         working-directory: master
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}


### PR DESCRIPTION
… tests

There is no need to collect and run other tests on the Node.js
backward compatibility tests. In fact, running all the tests are
wrong, as there are unit tests, that are specific to master, which
does not apply old client codes.