### PR TITLE
Disable transitive dependencies

### DIFF
--- a/util.py
+++ b/util.py
@@ -341,6 +341,7 @@ def download_via_maven(
         "mvn",
         "-q",
         "dependency:get",
+        "-Dtransitive=false",
         "-DrepoUrl=" + repo,
         "-Dartifact=" + artifact,
         "-Ddest=" + dst,


### PR DESCRIPTION
Fixes https://github.com/hazelcast/client-compatibility-suites/runs/6130345800?check_suite_focus=true by disabling transitive dependencies.