### PR TITLE
[TRIVIAL] Upgraded Go to 1.18

### DIFF
--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -108,7 +108,7 @@ jobs:
     - name: Set up Golang
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.15.15'
+        go-version: '^1.18.3'
 
     - name: Checkout to scripts
       uses: actions/checkout@v2

--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -48,7 +48,7 @@ jobs:
             check-latest: true
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15'
+          go-version: '1.18'
             
       - name: Checkout the ${{ github.event.inputs.branch_name }}     
         uses: actions/checkout@v2

--- a/HazelcastCloudTests/gohazelcastcloudtests/go.mod
+++ b/HazelcastCloudTests/gohazelcastcloudtests/go.mod
@@ -1,6 +1,6 @@
 module gohazelcastcloudtests
 
-go 1.16
+go 1.18
 
 require (
 	github.com/apache/thrift v0.14.1

--- a/KubernetesExternalClients/go/go.mod
+++ b/KubernetesExternalClients/go/go.mod
@@ -1,6 +1,6 @@
 module kubernetesTest/project
 
-go 1.16
+go 1.18
 
 require (
 	github.com/hazelcast/hazelcast-go-client v1.0.0

--- a/KubernetesInternalClients/go/Dockerfile
+++ b/KubernetesInternalClients/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine
+FROM golang:1.18-alpine
 
 RUN mkdir /app
 

--- a/KubernetesInternalClients/go/go.mod
+++ b/KubernetesInternalClients/go/go.mod
@@ -1,6 +1,6 @@
 module kubernetesTest/project
 
-go 1.16
+go 1.18
 
 require (
 	github.com/hazelcast/hazelcast-go-client <InputBranchName>


### PR DESCRIPTION
Latest version of the Go client requires 1.17. Upgraded the Go version to 1.18 to be a bot more future-proof.