### PR TITLE
Missing Config file extracted from JAR file

### DIFF
--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -390,9 +390,9 @@ jobs:
       - name: Extract Default Config XML
         shell: bash
         run: | 
-          cp .\temp\lib\hazelcast-${{ github.event.inputs.hz_version }}-SNAPSHOT.jar .\temp\lib\extracted\hazelcast.jar 
-          jar xf .\temp\lib\extracted\hazelcast.jar
-          cp .\temp\lib\extracted\hazelcast-default.xml .\temp\lib\hazelcast-${{ github.event.inputs.hz_version }}-SNAPSHOT.xml
+          cp ./temp/lib/hazelcast-${{ github.event.inputs.hz_version }}-SNAPSHOT.jar ./temp/lib/extracted/hazelcast.jar 
+          jar xf ./temp/lib/extracted/hazelcast.jar
+          cp ./temp/lib/extracted/hazelcast-default.xml ./temp/lib/hazelcast-${{ github.event.inputs.hz_version }}-SNAPSHOT.xml
         working-directory: tag
       - name: Run non-enterprise tests
         if: ${{ matrix.server_kind == 'os' }}

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -387,17 +387,24 @@ jobs:
         run: |
           git submodule update --init
         working-directory: tag
+      - name: Extract Default Config XML
+        shell: bash
+        run: | 
+          cp .\temp\lib\hazelcast-${{ github.event.inputs.hz_version }}-SNAPSHOT.jar .\temp\lib\extracted\hazelcast.jar 
+          jar xf .\temp\lib\extracted\hazelcast.jar
+          cp .\temp\lib\extracted\hazelcast-default.xml .\temp\lib\hazelcast-${{ github.event.inputs.hz_version }}-SNAPSHOT.xml
+        working-directory: tag
       - name: Run non-enterprise tests
         if: ${{ matrix.server_kind == 'os' }}
         shell: bash
-        run: ./hz.sh clean,build,test -server ${{ github.event.inputs.hz_version }}
+        run: ./hz.sh clean,build,test -server ${{ github.event.inputs.hz_version }}-SNAPSHOT
         working-directory: tag      
         env:
           HAZELCAST_SERVER_VERSION: ${{ github.event.inputs.hz_version }}
       - name: Run all tests
         if: ${{ matrix.server_kind == 'enterprise' }}
         shell: bash
-        run: ./hz.sh -enterprise clean,build,test -server ${{ github.event.inputs.hz_version }}
+        run: ./hz.sh -enterprise clean,build,test -server ${{ github.event.inputs.hz_version }}-SNAPSHOT
         working-directory: tag
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -390,14 +390,14 @@ jobs:
       - name: Run non-enterprise tests
         if: ${{ matrix.server_kind == 'os' }}
         shell: bash
-        run: ./hz.sh clean,build,test -server ${{ github.event.inputs.hz_version }}-SNAPSHOT
+        run: ./hz.sh clean,build,test -server ${{ github.event.inputs.hz_version }}
         working-directory: tag      
         env:
           HAZELCAST_SERVER_VERSION: ${{ github.event.inputs.hz_version }}
       - name: Run all tests
         if: ${{ matrix.server_kind == 'enterprise' }}
         shell: bash
-        run: ./hz.sh -enterprise clean,build,test -server ${{ github.event.inputs.hz_version }}-SNAPSHOT
+        run: ./hz.sh -enterprise clean,build,test -server ${{ github.event.inputs.hz_version }}
         working-directory: tag
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}


### PR DESCRIPTION
Not to download from maven or a repo, required files should be in the directory. Config file was missing. A step added to extract the default xml file to lib directory as `hazelcast-{version}.xml`.