### PR TITLE
Explicitly install go

### DIFF
--- a/.github/workflows/cloud_go_client_test.yaml
+++ b/.github/workflows/cloud_go_client_test.yaml
@@ -38,7 +38,7 @@ jobs:
           java-version: 8
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '^1.18.7'
 

--- a/.github/workflows/cloud_go_client_test.yaml
+++ b/.github/workflows/cloud_go_client_test.yaml
@@ -37,6 +37,11 @@ jobs:
         with:
           java-version: 8
 
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.18.7'
+
       - name: Change go.mod file depended branch name and go mod tidy
         run: |
           cd HazelcastCloudTests/gohazelcastcloudtests


### PR DESCRIPTION
The default installed version of Go in the workflow container for the Cloud test is 1.17. This PR installs Go explicitly.