### PR TITLE
Generate tests-jar for 5.2.0

### DIFF
--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -57,6 +57,12 @@ jobs:
           path: hazelcast-enterprise
           ref: ${{ github.event.inputs.branch_name }}
           token: ${{ secrets.GH_PAT }}
+      - name: Checkout to scripts
+        uses: actions/checkout@v2
+      - name: Apply tests-jar diff for 5.2.0
+        if: ${{ github.event.inputs.hz_version == '5.2.0' }}
+        run: git apply $GITHUB_WORKSPACE/tests-jar.diff
+        working-directory: hazelcast-enterprise
       - name: Build JARs
         run: mvn clean install -DskipTests=True
         working-directory: hazelcast

--- a/tests-jar.diff
+++ b/tests-jar.diff
@@ -1,0 +1,60 @@
+diff --git a/distribution/pom.xml b/distribution/pom.xml
+index ee01064d6..924afec4e 100644
+--- a/distribution/pom.xml
++++ b/distribution/pom.xml
+@@ -19,6 +19,18 @@
+ 
+     <build>
+         <plugins>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-jar-plugin</artifactId>
++                <executions>
++                    <execution>
++                        <phase>none</phase>
++                        <goals>
++                            <goal>test-jar</goal>
++                        </goals>
++                    </execution>
++                </executions>
++            </plugin>
+             <plugin>
+                 <artifactId>maven-dependency-plugin</artifactId>
+                 <version>3.2.0</version>
+diff --git a/pom.xml b/pom.xml
+index 6ee0718c0..3b214fde5 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -250,7 +250,31 @@
+                     <encoding>${project.build.sourceEncoding}</encoding>
+                 </configuration>
+             </plugin>
+-
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-jar-plugin</artifactId>
++                <version>3.2.2</version>
++                <configuration>
++                    <archive>
++                        <index>true</index>
++                        <compress>true</compress>
++                        <!-- Not needed for now -->
++                        <!-- manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile -->
++                    </archive>
++                    <excludes>
++                        <exclude>**/*.html</exclude>
++                        <exclude>**/*.sh</exclude>
++                        <exclude>**/*.bat</exclude>
++                    </excludes>
++                </configuration>
++                <executions>
++                    <execution>
++                        <goals>
++                            <goal>test-jar</goal>
++                        </goals>
++                    </execution>
++                </executions>
++            </plugin>
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
We don't generate the tests JAR anymore in 5.2.0. But, we haven't updated the client compatibility tests to drop the dependency on it.

This PR adds the git diff to patch the enterprise code so that it also generates the tests JAR.

We should revert these changes once we implement the proper solution.