### PR TITLE
Apply diff to generate tests JAR if the server version is 5.2.1

### DIFF
--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -61,8 +61,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: master
-      - name: Apply tests-jar diff for 5.2.0
-        if: ${{ github.event.inputs.hz_version == '5.2.0' }}
+      - name: Apply tests-jar diff for 5.2.1
+        if: ${{ github.event.inputs.hz_version == '5.2.1' }}
         run: git apply $GITHUB_WORKSPACE/master/tests-jar.diff
         working-directory: hazelcast-enterprise
       - name: Build JARs


### PR DESCRIPTION
We are about to run the backward compatibility tests for 5.2.1, and we need this hack for that version to be able to generate enterprise tests JAR.