### PR TITLE
Run C++ tests with Ubuntu-20.04

### DIFF
--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -432,7 +432,7 @@ jobs:
         run: echo "::set-output name=matrix::$( python get_client_matrix.py --client cpp --option tag --use-latest-patch-versions )"
   test_cpp_clients:
     needs: [ upload_jars, setup_cpp_client_matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Due to client not being able to compile on Ubuntu-22.04, we have to run C++ tests on Ubuntu-20.04, until we sort the problems with the recent OpenSSL versions in the clients, and make them compile again.