### PR TITLE
Checkout to private-test-artifacts repo after checking out to master

### DIFF
--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -39,6 +39,8 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
     name: Test CSharp ${{ github.event.inputs.branch_name }} branch against ${{ matrix.kind }} ${{ matrix.version }} server on ${{ matrix.os }}
     steps:
+      - name: Checkout to scripts
+        uses: actions/checkout@v2
       - name: Checkout to test artifacts
         if: ${{ matrix.kind == 'enterprise' }}
         uses: actions/checkout@v2
@@ -47,8 +49,6 @@ jobs:
           path: certs
           ref: data
           token: ${{ secrets.GH_PAT }}
-      - name: Checkout to scripts
-        uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -38,6 +38,8 @@ jobs:
         kind: [os, enterprise]
     name: Test Node.js client against ${{ matrix.kind }} ${{ matrix.version }} server
     steps:
+      - name: Checkout to scripts
+        uses: actions/checkout@v2
       - name: Checkout to test artifacts
         if: ${{ matrix.kind == 'enterprise' }}
         uses: actions/checkout@v2
@@ -46,8 +48,6 @@ jobs:
           path: certs
           ref: data
           token: ${{ secrets.GH_PAT }}
-      - name: Checkout to scripts
-        uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -38,6 +38,8 @@ jobs:
         kind: [os, enterprise]
     name: Test Python client against ${{ matrix.kind }} ${{ matrix.version }} server
     steps:
+      - name: Checkout to scripts
+        uses: actions/checkout@v2
       - name: Checkout to test artifacts
         if: ${{ matrix.kind == 'enterprise' }}
         uses: actions/checkout@v2
@@ -46,8 +48,6 @@ jobs:
           path: certs
           ref: data
           token: ${{ secrets.GH_PAT }}
-      - name: Checkout to scripts
-        uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
In workflows where we use
```
      - name: Checkout to scripts
        uses: actions/checkout@v2
```

we should checkout to other repos after that, so that they can be placed under the $GITHUB_WORKSPACE correctly.