### PR TITLE
Use ubuntu-20.04 for C++ compatibility tests

### DIFF
--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   setup_server_matrix:
     name: Setup the server test matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:


### PR DESCRIPTION
The tests will not compile with the latest version. We will be using 20.04 for now.