### PR TITLE
Upgrade Java Version on Workflow

### DIFF
--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -83,16 +83,10 @@ jobs:
       - name: Run all tests        
         shell: pwsh
         if: ${{ matrix.kind == 'enterprise' }}
-        run: ./hz.ps1 -enterprise -noRestore -localRestore -server ${{ matrix.version }} -tf "test =~ Networking.ClientSslTests.ValidateChain" -verbose-tests test ${{ secrets.GH_PAT }}
+        run: ./hz.ps1 -enterprise -noRestore -localRestore -server ${{ matrix.version }} test ${{ secrets.GH_PAT }}
         working-directory: client        
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}
-      - name: Upload tmp dir
-        if: always()       
-        uses: actions/upload-artifact@v3
-        with:
-          name: temp-dir
-          path: client/temp/rc
 
           

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -81,9 +81,9 @@ jobs:
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}
       - name: Run all tests
         uses: actions/upload-artifact@v3
-          with:
-            name: temp-dir
-            path: temp
+        with:
+          name: temp-dir
+          path: temp
         shell: pwsh
         if: ${{ matrix.kind == 'enterprise' }}
         run: ./hz.ps1 -enterprise -server ${{ matrix.version }} -tf "test =~ Networking.ClientSslTests.ValidateChain" -verbose-tests test ${{ secrets.GH_PAT }}

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -75,7 +75,7 @@ jobs:
         working-directory: client      
       - name: Run non-enterprise tests
         shell: pwsh
-        if: ${{ matrix.kind == 'oss' }}
+        if: ${{ matrix.kind == 'os' }}
         run: ./hz.ps1 -server ${{ matrix.version }} test
         working-directory: client
         env:

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -38,11 +38,7 @@ jobs:
         kind: [os, enterprise]
         os: [ ubuntu-latest, windows-latest ]
     name: Test CSharp ${{ github.event.inputs.branch_name }} branch against ${{ matrix.kind }} ${{ matrix.version }} server on ${{ matrix.os }}
-    steps:
-      - uses: actions/upload-artifact@v3
-          with:
-            name: temp-dir
-            path: temp
+    steps:      
       - name: Checkout to scripts
         uses: actions/checkout@v2
       - name: Setup Python
@@ -84,6 +80,10 @@ jobs:
         env:
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}
       - name: Run all tests
+        uses: actions/upload-artifact@v3
+          with:
+            name: temp-dir
+            path: temp
         shell: pwsh
         if: ${{ matrix.kind == 'enterprise' }}
         run: ./hz.ps1 -enterprise -server ${{ matrix.version }} -tf "test =~ Networking.ClientSslTests.ValidateChain" -verbose-tests test ${{ secrets.GH_PAT }}

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -88,9 +88,10 @@ jobs:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}
       - name: Upload tmp dir
+        working-directory: client 
         uses: actions/upload-artifact@v3
         with:
           name: temp-dir
-          path: temp
+          path: temp/rc
 
           

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '8'
       - name: Checkout to ${{ github.event.inputs.branch_name }}
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -41,8 +41,8 @@ jobs:
     steps:
       - uses: actions/upload-artifact@v3
           with:
-          name: temp-dir
-          path: temp
+            name: temp-dir
+            path: temp
       - name: Checkout to scripts
         uses: actions/checkout@v2
       - name: Setup Python

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -87,11 +87,10 @@ jobs:
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}
-      - name: Upload tmp dir
-        working-directory: client 
+      - name: Upload tmp dir        
         uses: actions/upload-artifact@v3
         with:
           name: temp-dir
-          path: temp/rc
+          path: client/temp/rc
 
           

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: '8'
+          java-version: '11'
       - name: Checkout to ${{ github.event.inputs.branch_name }}
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -74,7 +74,7 @@ jobs:
         working-directory: client      
       - name: Run non-enterprise tests
         shell: pwsh
-        if: ${{ matrix.kind == 'os' }}
+        if: ${{ matrix.kind == 'oss' }}
         run: ./hz.ps1 -server ${{ matrix.version }} test
         working-directory: client
         env:
@@ -82,7 +82,7 @@ jobs:
       - name: Run all tests
         shell: pwsh
         if: ${{ matrix.kind == 'enterprise' }}
-        run: ./hz.ps1 -enterprise -server ${{ matrix.version }} test ${{ secrets.GH_PAT }}
+        run: ./hz.ps1 -enterprise -server ${{ matrix.version }} -tf "test =~ Networking.ClientSslTests.ValidateChain" -verbose-tests test ${{ secrets.GH_PAT }}
         working-directory: client
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -87,7 +87,8 @@ jobs:
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}
-      - name: Upload tmp dir        
+      - name: Upload tmp dir
+        if: always()       
         uses: actions/upload-artifact@v3
         with:
           name: temp-dir

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -87,7 +87,7 @@ jobs:
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}
-        - uses: actions/upload-artifact@v3
-            with:
-            name: rc-logs
-            path: temp/rc
+          - uses: actions/upload-artifact@v3
+              with:
+              name: temp-dir
+              path: temp

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Run all tests        
         shell: pwsh
         if: ${{ matrix.kind == 'enterprise' }}
-        run: ./hz.ps1 -enterprise -server ${{ matrix.version }} -tf "test =~ Networking.ClientSslTests.ValidateChain" -verbose-tests test ${{ secrets.GH_PAT }}
+        run: ./hz.ps1 -enterprise -noRestore -localRestore -server ${{ matrix.version }} -tf "test =~ Networking.ClientSslTests.ValidateChain" -verbose-tests test ${{ secrets.GH_PAT }}
         working-directory: client        
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -79,11 +79,7 @@ jobs:
         working-directory: client
         env:
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}
-      - name: Run all tests
-        uses: actions/upload-artifact@v3
-        with:
-          name: temp-dir
-          path: temp
+      - name: Run all tests        
         shell: pwsh
         if: ${{ matrix.kind == 'enterprise' }}
         run: ./hz.ps1 -enterprise -server ${{ matrix.version }} -tf "test =~ Networking.ClientSslTests.ValidateChain" -verbose-tests test ${{ secrets.GH_PAT }}
@@ -91,4 +87,10 @@ jobs:
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}
+      - name: Upload tmp dir
+        uses: actions/upload-artifact@v3
+        with:
+          name: temp-dir
+          path: temp
+
           

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -39,6 +39,10 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
     name: Test CSharp ${{ github.event.inputs.branch_name }} branch against ${{ matrix.kind }} ${{ matrix.version }} server on ${{ matrix.os }}
     steps:
+      - uses: actions/upload-artifact@v3
+          with:
+          name: temp-dir
+          path: temp
       - name: Checkout to scripts
         uses: actions/checkout@v2
       - name: Setup Python
@@ -83,11 +87,8 @@ jobs:
         shell: pwsh
         if: ${{ matrix.kind == 'enterprise' }}
         run: ./hz.ps1 -enterprise -server ${{ matrix.version }} -tf "test =~ Networking.ClientSslTests.ValidateChain" -verbose-tests test ${{ secrets.GH_PAT }}
-        working-directory: client
+        working-directory: client        
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}
-          - uses: actions/upload-artifact@v3
-              with:
-              name: temp-dir
-              path: temp
+          

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             2.1.x
@@ -55,9 +55,10 @@ jobs:
             6.0.x
             7.0.x
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 8
+          distribution: 'adopt'
+          java-version: '11'
       - name: Checkout to ${{ github.event.inputs.branch_name }}
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -87,3 +87,7 @@ jobs:
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}
+        - uses: actions/upload-artifact@v3
+            with:
+            name: rc-logs
+            path: temp/rc


### PR DESCRIPTION
Upgraded Java 8 to 11 since keystore format (PKCS12) that we use in tests is not compatible  with Java 8. So, that upgraded the Java version.