### PR TITLE
Increase retry timeout for .net client.

### DIFF
--- a/KubernetesInternalClients/csharp/KubernetesTest/Program.cs
+++ b/KubernetesInternalClients/csharp/KubernetesTest/Program.cs
@@ -21,7 +21,7 @@ namespace Client
             // this must be consistent with what's in the GitHub action: if the action waits for 120s before testing
             // the log, then we must set an invocation retry timeout greater than 120s, else the invocations will
             // start and exceptions *will* be reported
-            options.Messaging.RetryTimeoutSeconds = 180;
+            options.Messaging.RetryTimeoutSeconds = 240;
             
             await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
             await using var map = await client.GetMapAsync<string, string>("map");


### PR DESCRIPTION
It seems retry timeout must be bigger than kubectl timeout which is changed here https://github.com/hazelcast/client-compatibility-suites/pull/61