### PR TITLE
Enable nightly build for cpp-client

### DIFF
--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -11,6 +11,8 @@ on:
         description: Name of the branch to test client from
         required: true
         default: master
+  schedule:
+    - cron: '0 20 * * *'
 jobs:
   setup_server_matrix:
     name: Setup the server test matrix


### PR DESCRIPTION
Since this repo is public there is no fee to run compatibility tests nightly. These tests are generally blocker for us when we are close to release dates. So enabling nightly build will allow us to see before we are about to release.