### PR TITLE
Increase compt. version for tests.

### DIFF
--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -430,7 +430,7 @@ jobs:
 
       - name: Backport SSL Tests and hz script for client < 5.2.0
         id: backport-tests
-        if: ${{  ((steps.version.outputs.major == '5' && steps.version.outputs.minor < '2') || (steps.version.outputs.major == '4')) }}
+        if: ${{  ((steps.version.outputs.major == '5' && steps.version.outputs.minor < '3') || (steps.version.outputs.major == '4')) }}
         shell: pwsh
         working-directory: tag
         run: |


### PR DESCRIPTION
We've fixed the SSL tests for <5.2. The fix was also include run with Hazelcast BETA snapshots. Although, client 5.2 doesn't have any issues with ssl tests, it fails due to BETA versioning. By increasing the backward fix coverage, the hz.ps1 script will run tests with BETA snapshots.