### PR TITLE
Remove nightly run for C++ client

### DIFF
--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -11,8 +11,6 @@ on:
         description: Name of the branch to test client from
         required: true
         default: master
-  schedule:
-    - cron: '0 20 * * *'
 jobs:
   setup_server_matrix:
     name: Setup the server test matrix


### PR DESCRIPTION
It fails constantly, and there is no active development in the C++ client. Therefore, I think it makes sense to remove the nightly tests.