### PR TITLE
Update cloud_csharp_client_test.yaml

### DIFF
--- a/.github/workflows/cloud_csharp_client_test.yaml
+++ b/.github/workflows/cloud_csharp_client_test.yaml
@@ -81,7 +81,7 @@ jobs:
           HAZELCAST_SERVER_VERSION: ${{ github.event.inputs.hzVersion }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
         run: |
-          ./hz.ps1 -server ${{ github.event.inputs.hzVersion }} test -tf "test == /Hazelcast.Tests.Cloud.ServerlessCloudTests/"
+          ./hz.ps1 -server ${{ github.event.inputs.hzVersion }} test -tf "test == /Hazelcast.Tests.Cloud.ServerlessCloudTests/" ${{ secrets.GH_PAT }}
         working-directory: client
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Remove enterprise tag to run explicit cloud tests due some Nunit issues.