### PR TITLE
Update java to 11 in server compat tests

### DIFF
--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: Checkout to test artifacts
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Needed for 5.4 release. See https://github.com/hazelcast/client-compatibility-suites/actions/runs/7253539308/job/19760341566