### PR TITLE
Update GitHub actions to Java 17 [HZ-4166]

### DIFF
--- a/.github/java-config.yml
+++ b/.github/java-config.yml
@@ -1,0 +1,2 @@
+java-version: "17"
+distribution: "temurin"

--- a/.github/workflows/cloud_csharp_client_test.yaml
+++ b/.github/workflows/cloud_csharp_client_test.yaml
@@ -25,18 +25,24 @@ jobs:
     name: Cloud tests with .NET
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
-      - name: Install Java
-        uses: actions/setup-java@v3
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-          distribution: 'zulu'
-          java-version: 11
+          config: ${{ github.workspace }}/.github/java-config.yml
+
+      - name: Install Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
 
       - name: Install .NET
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/cloud_go_client_test.yaml
+++ b/.github/workflows/cloud_go_client_test.yaml
@@ -25,17 +25,24 @@ jobs:
     name: Cloud tests with go
     steps:
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
 
-      - name: Setup Java
-        uses: actions/setup-java@v1
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-          java-version: 11
+          config: ${{ github.workspace }}/.github/java-config.yml
+  
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
 
       - name: Setup Go
         uses: actions/setup-go@v3

--- a/.github/workflows/cloud_java_client_test.yaml
+++ b/.github/workflows/cloud_java_client_test.yaml
@@ -20,12 +20,19 @@ jobs:
     name: Cloud tests with Java
     steps:
       - name: Checkout to scripts
-        uses: actions/checkout@v2
-          
-      - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v4
+
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-          java-version: 11
+          config: ${{ github.workspace }}/.github/java-config.yml
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
           
       - name: Run cloud tests for Viridian
         env:

--- a/.github/workflows/cloud_nodejs_client_test.yaml
+++ b/.github/workflows/cloud_nodejs_client_test.yaml
@@ -25,18 +25,25 @@ jobs:
     name: Cloud tests with nodejs
     steps:
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-          
-      - name: Setup Java
-        uses: actions/setup-java@v1
+
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-          java-version: 11
-          
+          config: ${{ github.workspace }}/.github/java-config.yml
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
+
       - name: Checkout to ${{ github.event.inputs.branch_name }}
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/cloud_python_client_test.yaml
+++ b/.github/workflows/cloud_python_client_test.yaml
@@ -25,17 +25,24 @@ jobs:
     name: Cloud tests with python
     steps:
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-          
-      - name: Setup Java
-        uses: actions/setup-java@v1
+
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-          java-version: 11
+          config: ${{ github.workspace }}/.github/java-config.yml
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
           
       - name: Checkout to ${{ github.event.inputs.branch_name }}
         uses: actions/checkout@v2

--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Set server matrix
         id: set-matrix
@@ -41,12 +41,18 @@ jobs:
     name: Test Cpp client against ${{ matrix.kind }} ${{ matrix.version }} server on ubuntu-latest
     steps:
         
-      - name: Setup Java
-        uses: actions/setup-java@v2
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-            distribution: 'adopt'
-            java-version: '8'
-            check-latest: true
+          config: ${{ github.workspace }}/.github/java-config.yml
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
+          check-latest: true
 
       - name: Checkout to test artifacts
         if: ${{ matrix.kind == 'enterprise' }}

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -40,7 +40,7 @@ jobs:
     name: Test CSharp ${{ github.event.inputs.branch_name }} branch against ${{ matrix.kind }} ${{ matrix.version }} server on ${{ matrix.os }}
     steps:      
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -54,11 +54,17 @@ jobs:
             5.0.x
             6.0.x
             7.0.x
-      - name: Setup Java
-        uses: actions/setup-java@v3
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-          distribution: 'adopt'
-          java-version: '11'
+          config: ${{ github.workspace }}/.github/java-config.yml
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
       - name: Checkout to ${{ github.event.inputs.branch_name }}
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Set server matrix
         id: set-matrix
@@ -40,12 +40,18 @@ jobs:
     name: Test Go client against enterprise ${{ matrix.version }} server on ubuntu-latest
     steps:
         
-      - name: Setup Java
-        uses: actions/setup-java@v2
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-            distribution: 'adopt'
-            java-version: '8'
-            check-latest: true
+          config: ${{ github.workspace }}/.github/java-config.yml
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
+          check-latest: true
       - uses: actions/setup-go@v2
         with:
           go-version: '1.18'

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -39,7 +39,7 @@ jobs:
     name: Test Node.js client against ${{ matrix.kind }} ${{ matrix.version }} server
     steps:
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Checkout to test artifacts
         if: ${{ matrix.kind == 'enterprise' }}
         uses: actions/checkout@v2
@@ -56,10 +56,16 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
-      - name: Setup Java
-        uses: actions/setup-java@v1
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-          java-version: 11
+          config: ${{ github.workspace }}/.github/java-config.yml
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
       - name: Download JARs
         run: python download_server_jars.py --version ${{ matrix.version }} --server-kind ${{ matrix.kind }} --dst jars
       - name: Copy certificates JAR to destination with the appropriate name

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -39,7 +39,7 @@ jobs:
     name: Test Python client against ${{ matrix.kind }} ${{ matrix.version }} server
     steps:
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Checkout to test artifacts
         if: ${{ matrix.kind == 'enterprise' }}
         uses: actions/checkout@v2
@@ -52,10 +52,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Setup Java
-        uses: actions/setup-java@v1
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-          java-version: 11
+          config: ${{ github.workspace }}/.github/java-config.yml
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
       - name: Download JARs
         run: python download_server_jars.py --version ${{ matrix.version }} --server-kind ${{ matrix.kind }} --dst jars
       - name: Copy certificates JAR to destination with the appropriate name

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -40,10 +40,20 @@ jobs:
     name: Create and upload JARs
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Java
-        uses: actions/setup-java@v1
+      - name: Checkout to scripts
+        uses: actions/checkout@v4
         with:
-          java-version: 11
+          path: master
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
+        with:
+          config: ${{ github.workspace }}/.github/java-config.yml
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
       - name: Checkout to test artifacts
         uses: actions/checkout@v2
         with:
@@ -64,10 +74,6 @@ jobs:
           path: hazelcast-enterprise
           ref: ${{ github.event.inputs.branch_name }}
           token: ${{ secrets.GH_PAT }}
-      - name: Checkout to scripts
-        uses: actions/checkout@v2
-        with:
-          path: master
       - name: Build JARs
         run: mvn clean install -DskipTests=True
         working-directory: hazelcast
@@ -138,15 +144,21 @@ jobs:
     name: Test Python client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Setup Java
-        uses: actions/setup-java@v1
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-          java-version: 11
+          config: ${{ github.workspace }}/.github/java-config.yml
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
       - name: Checkout to master
         uses: actions/checkout@v2
         with:
@@ -235,7 +247,7 @@ jobs:
         server_kind: [ os, enterprise ]
     name: Test Node.js client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -244,10 +256,16 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
-      - name: Setup Java
-        uses: actions/setup-java@v1
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-          java-version: 11
+          config: ${{ github.workspace }}/.github/java-config.yml
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
       - name: Checkout to master
         uses: actions/checkout@v2
         with:
@@ -344,16 +362,23 @@ jobs:
         server_kind: [ os, enterprise ]
     name: Test Csharp client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
 
-      - name: Setup Java
-        uses: actions/setup-java@v1
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-          java-version: 11
+          config: ${{ github.workspace }}/.github/java-config.yml
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
 
       - name: Install .NET
         uses: actions/setup-dotnet@v3
@@ -523,15 +548,21 @@ jobs:
         server_kind: [ enterprise ] #TODO When tests are divided as OS, ENTERPRISE, OS matrix will be added
     name: Test CPP client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Setup Java
-        uses: actions/setup-java@v1
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-          java-version: 11
+          config: ${{ github.workspace }}/.github/java-config.yml
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
       - name: Checkout master
         uses: actions/checkout@v2
         with:
@@ -640,11 +671,17 @@ jobs:
         
     name: Test Go client ${{ matrix.client_tag }} with enterprise server on ubuntu-latest
     steps:
-        
-      - name: Setup Java
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
         with:
-          java-version: 11
+          config: ${{ github.workspace }}/.github/java-config.yml
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
             
       - name: Checkout the ${{ matrix.client_tag }}     
         uses: actions/checkout@v2


### PR DESCRIPTION
As part of Hazelcast 5.4 moving to Java 17, the GitHub actions need to be configured to use the newer Java version.

Changes:
- configuration externalised to make future updates easier
   - Java version now consistently 17 (was a mix of 8 & 11)
   - Java distribution now consistently Temurin (was a mix of AdoptOpenJDK & Zulu)
- GitHub actions upgraded to latest
   - `actions/checkout`
   - `actions/setup-java`

Fixes [HZ-4166](https://hazelcast.atlassian.net/browse/HZ-4166)

[HZ-4166]: https://hazelcast.atlassian.net/browse/HZ-4166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ