### PR TITLE
Remove Java >=15 guard case

### DIFF
--- a/utils/net/hz-latest.ps1
+++ b/utils/net/hz-latest.ps1
@@ -1321,15 +1321,6 @@ function ensure-java {
             `
             "--add-opens",   "java.base/java.io=ALL-UNNAMED" `
         )
-
-        # "Scripting is currently unsupported for Java 15 and newer. These versions
-        #  of Java do not come with a JavaScript engine, which is necessary for this
-        #  feature to work."
-        $pos = $javaVersion.IndexOf('.')
-        $javaMajor = $javaVersion.SubString(0, $pos)
-        if (-not ($javaVersion -lt "12") ) {
-            Die "Java version >11 not supported (JavaScript scripting not supported)"
-        }
 	}
 }
 


### PR DESCRIPTION
Now that [`hazelcast-remote-controller` supports Java 17](https://github.com/hazelcast/hazelcast-remote-controller/pull/69), the guard case preventing this can be removed.