### PR TITLE
Downgrade GitHub actions to Java 11

### DIFF
--- a/.github/java-config.yml
+++ b/.github/java-config.yml
@@ -1,2 +1,2 @@
-java-version: "17"
+java-version: "11"
 distribution: "temurin"


### PR DESCRIPTION
[`hazelcast-remote-controller` does not support Java 17](https://github.com/hazelcast/hazelcast-remote-controller/issues/70), which is causing [test failures](https://github.com/srknzl/client-compatibility-suites/actions/runs/7815412488/job/21319268716) since the [GitHub actions were upgraded to use Java 17](https://github.com/hazelcast/client-compatibility-suites/pull/84).

It's my understanding that `hazelcast-remote-controller` abstract needing a specific JDK so we _should_ be ok to roll back to 11.

This isn't simply reverting https://github.com/hazelcast/client-compatibility-suites/pull/84 because I think having it centralised and consistent is still valuable.