### PR TITLE
Java doesn't like null Cert Name-Fixes Failing SSL Tests on .Net Client

### DIFF
--- a/utils/net/ssl/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
+++ b/utils/net/ssl/src/Hazelcast.Net.Tests/Networking/ClientSslTestBase.cs
@@ -278,7 +278,7 @@ namespace Hazelcast.Tests.Networking
             bool? validateCertificateChain = null,
             bool? validateCertificateName = null,
             bool? checkCertificateRevocation = null,
-            string serverCertificateName = null,
+            string serverCertificateName = "hazelcast.com", // Must be something meaningful otherwise Java throws. 
             string clientCertificatePath = null,
             string clientCertificatePassword = null,
             bool failFast = false)


### PR DESCRIPTION
Java doesn't like null certificate names anymore. Although it's fixed in `master` older releases didn't get that update on tests. So, PR includes a fix for older .Net client releases on SSL tests with a default dummy certificate name.