### PR TITLE
Ignore 4.0.z and 1.0.z & 1.1.z (go) versions in tests

### DIFF
--- a/get_client_matrix.py
+++ b/get_client_matrix.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 
     if client_kind == ClientKind.GO:
         filtered_major_version = [1]
-        unsupported_versions = [Version("1.0")]
+        unsupported_versions = [Version("1.0"), Version("1.1")]
     else:
         filtered_major_version = [4, 5]
         unsupported_versions = [Version("4.0")]

--- a/get_client_matrix.py
+++ b/get_client_matrix.py
@@ -5,8 +5,10 @@ from util import (
     ClientKind,
     ClientReleaseParser,
     StableReleaseFilter,
+    SupportedReleaseFilter,
     MajorVersionFilter,
     MatrixOptionKind,
+    Version,
     get_option_from_release,
     get_latest_patch_releases,
 )
@@ -57,11 +59,15 @@ if __name__ == "__main__":
 
     if client_kind == ClientKind.GO:
         filtered_major_version = [1]
+        unsupported_versions = [Version("1.0")]
     else:
         filtered_major_version = [4, 5]
+        unsupported_versions = [Version("4.0")]
+
     filters = [
         MajorVersionFilter(filtered_major_version),
         StableReleaseFilter(),
+        SupportedReleaseFilter(unsupported_versions)
     ]
 
     client_release_parser = ClientReleaseParser(client_kind, filters)

--- a/get_server_matrix.py
+++ b/get_server_matrix.py
@@ -5,8 +5,10 @@ from typing import List
 from util import (
     MajorVersionFilter,
     ServerReleaseParser,
+    SupportedReleaseFilter,
     get_latest_patch_releases,
     ReleaseFilter,
+    Version
 )
 
 
@@ -20,7 +22,8 @@ def parse_args() -> argparse.Namespace:
 
 if __name__ == "__main__":
     args = parse_args()
-    filters: List[ReleaseFilter] = [MajorVersionFilter([4, 5])]
+    unsupported_versions = [Version("4.0")]
+    filters: List[ReleaseFilter] = [MajorVersionFilter([4, 5]), SupportedReleaseFilter(unsupported_versions)]
     server_release_parser = ServerReleaseParser(filters)
     releases = server_release_parser.get_all_releases()
     latest_patch_releases = get_latest_patch_releases(releases)

--- a/util.py
+++ b/util.py
@@ -149,6 +149,18 @@ class MajorVersionFilter(ReleaseFilter):
 class StableReleaseFilter(ReleaseFilter):
     def filter(self, release: Release) -> bool:
         return release.version.stable
+    
+
+class SupportedReleaseFilter(ReleaseFilter):
+    def __init__(self, unsupported_versions: List[Version]):
+        self._unsupported_versions = unsupported_versions
+
+    def filter(self, release: Release) -> bool:
+        for version in self._unsupported_versions:
+            if release.version.major == version.major and \
+               release.version.minor == version.minor:
+                return False
+        return True
 
 
 class AbstractReleaseParser(ABC):


### PR DESCRIPTION
These versions are not supported anymore. Thus I remove them from testing.

You can test the change by running 

* python3 get_client_matrix.py --client py --option tag --use-latest-patch-versions
* python3 get_client_matrix.py --client go --option tag --use-latest-patch-versions
* python3 get_server_matrix.py