### PR TITLE
Use commit hash (not tag) for `action-read-yaml` action version specification

### DIFF
--- a/.github/workflows/cloud_csharp_client_test.yaml
+++ b/.github/workflows/cloud_csharp_client_test.yaml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.9
 
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml

--- a/.github/workflows/cloud_go_client_test.yaml
+++ b/.github/workflows/cloud_go_client_test.yaml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.9
 
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml

--- a/.github/workflows/cloud_java_client_test.yaml
+++ b/.github/workflows/cloud_java_client_test.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml

--- a/.github/workflows/cloud_nodejs_client_test.yaml
+++ b/.github/workflows/cloud_nodejs_client_test.yaml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.9
 
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml

--- a/.github/workflows/cloud_python_client_test.yaml
+++ b/.github/workflows/cloud_python_client_test.yaml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.9
 
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml

--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -42,7 +42,7 @@ jobs:
     steps:
         
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -57,7 +57,7 @@ jobs:
             8.0.x
             
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml

--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
         
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version: 14
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           path: master
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/master/.github/java-config.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml
@@ -248,7 +248,7 @@ jobs:
         with:
           node-version: 14
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml
@@ -360,7 +360,7 @@ jobs:
           python-version: 3.9
 
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml
@@ -562,7 +562,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml
@@ -681,7 +681,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml


### PR DESCRIPTION
Currently we are referencing a tag when specifying the version of the `action-read-yaml` action, which is potentially mutable.

[It was requested](https://github.com/hazelcast/hazelcast-mono/pull/1181#discussion_r1537109860) that the commit SHA be used instead, as per the [GitHub actions security hardening guide](https://github.com/hazelcast/hazelcast-mono/pull/1181#discussion_r1537109860).

Updated the version specification to the commit hash of the [currently used version](https://github.com/pietrobolcato/action-read-yaml/releases/tag/1.1.0) - i.e. no changes to the actual version of the action being used.