### PR TITLE
Fix reconnect mode on .Net k8s Test

### DIFF
--- a/KubernetesInternalClients/csharp/KubernetesTest/Program.cs
+++ b/KubernetesInternalClients/csharp/KubernetesTest/Program.cs
@@ -15,7 +15,7 @@ namespace Client
             var options = new HazelcastOptionsBuilder().Build();
             Console.WriteLine("Reconnect mode is set");
             
-            options.Networking.ReconnectMode = ReconnectMode.ReconnectAsync;
+            options.Networking.ReconnectMode = ReconnectMode.ReconnectSync;
             options.Networking.Addresses.Add("hz-hazelcast");
             
             // this must be consistent with what's in the GitHub action: if the action waits for 120s before testing


### PR DESCRIPTION
Reconnect modes are implemented in .Net client as it should be. So, async mode throws as expected and sync doesn't. So, test is designed for sync reconnect mode. 