### PR TITLE
Use released Hazelcast `5.4.0` instead of `SNAPSHOT`

### DIFF
--- a/utils/net/no-java-check/hz.ps1
+++ b/utils/net/no-java-check/hz.ps1
@@ -15,7 +15,7 @@
 ## Hazelcast.NET Build Script
 
 # constant
-$defaultServerVersion="5.4.0-SNAPSHOT"
+$defaultServerVersion="5.4.0"
 
 # PowerShell errors can *also* be a pain
 # see https://stackoverflow.com/questions/10666035


### PR DESCRIPTION
Now `5.4.0` is released, the released version should be used in preferences to a pre-release `SNAPSHOT`.