### PR TITLE
Revert reading from github env for csharp client 

### DIFF
--- a/.github/java-config.yml
+++ b/.github/java-config.yml
@@ -1,0 +1,2 @@
+java-version: "17"	
+distribution: "temurin"	

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -65,13 +65,16 @@ jobs:
           compare-to: 5.3.0
             
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
+        id: java-config
+        with:
+          config: ${{ github.workspace }}/.github/java-config.yml
 
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
 
       - name: Checkout to ${{ github.event.inputs.branch_name }}
         uses: actions/checkout@v2

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -351,13 +351,16 @@ jobs:
           python-version: 3.9
 
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
+        id: java-config
+        with:
+          config: ${{ github.workspace }}/master/.github/java-config.yml
 
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
 
       - name: Install .NET
         uses: actions/setup-dotnet@v3


### PR DESCRIPTION
Reverts https://github.com/hazelcast/client-compatibility-suites/commit/a7b74d1dd0cd48f28d4eeaf8da5983c015578fe8 partially for csharp

It does not work because csharp runs on windows. Can be reverted back to env approach after the releases depending on client compat tests are complete. 