### PR TITLE
Upgrade GitHub actions to avoid deprecated `node` warnings

### DIFF
--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -48,7 +48,7 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - id: 'auth'
       uses: 'google-github-actions/auth@v1'
@@ -135,10 +135,10 @@ jobs:
         go-version: '^1.18.3'
 
     - name: Checkout to scripts
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
         
     - name: Checkout the go client repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: ${{ github.event.inputs.organization_name }}/hazelcast-go-client
         path: KubernetesExternalClients/go/clientSourceCode
@@ -163,15 +163,15 @@ jobs:
       
     steps:  
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
         
     - name: Checkout to scripts
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
         
     - name: Checkout the Python client repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: ${{ github.event.inputs.organization_name }}/hazelcast-python-client
         path: KubernetesExternalClients/python/clientSourceCode
@@ -201,10 +201,10 @@ jobs:
         node-version: 14
         
     - name: Checkout to scripts
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
         
     - name: Checkout the Nodejs client repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: ${{ github.event.inputs.organization_name }}/hazelcast-nodejs-client
         path: KubernetesExternalClients/nodejs/clientSourceCode
@@ -233,10 +233,10 @@ jobs:
         dotnet-version: |
             8.0.x
     - name: Checkout to scripts
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
         
     - name: Checkout the Csharp client repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: ${{ github.event.inputs.organization_name }}/hazelcast-csharp-client
         path: KubernetesExternalClients/csharp/clientSourceCode
@@ -263,10 +263,10 @@ jobs:
         
     steps: 
     - name: Checkout to scripts
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
         
     - name: Checkout the Cpp client repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: ${{ github.event.inputs.organization_name }}/hazelcast-cpp-client
         path: KubernetesExternalClients/cpp/clientSourceCode

--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -34,10 +34,10 @@ jobs:
    if: ${{ github.event.inputs.csharp_run != 'no' }}
    steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Checkout the client repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-csharp-client
           path: KubernetesInternalClients/csharp/clientSourceCode
@@ -72,10 +72,10 @@ jobs:
    if: ${{ github.event.inputs.python_run != 'no' }}
    steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Checkout the client repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-python-client
           path: KubernetesInternalClients/python/clientSourceCode
@@ -95,10 +95,10 @@ jobs:
    if: ${{ github.event.inputs.nodejs_run != 'no' }}
    steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Checkout the client repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-nodejs-client
           path: KubernetesInternalClients/nodejs/clientSourceCode
@@ -124,10 +124,10 @@ jobs:
    if: ${{ github.event.inputs.cpp_run != 'no' }}
    steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Checkout the client repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-cpp-client
           path: KubernetesInternalClients/cpp/clientSourceCode
@@ -147,7 +147,7 @@ jobs:
    if: ${{ github.event.inputs.go_run != 'no' }}
    steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Give the branch name to go.mod file
         run: |
@@ -173,7 +173,7 @@ jobs:
       
     steps:      
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set which client will be run
       id: set-matrix

--- a/.github/workflows/cloud_csharp_client_test.yaml
+++ b/.github/workflows/cloud_csharp_client_test.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -52,7 +52,7 @@ jobs:
             8.0.x
 
       - name: Checkout .NET client branch ${{ github.event.inputs.branch_name }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-csharp-client
           path: client

--- a/.github/workflows/cloud_go_client_test.yaml
+++ b/.github/workflows/cloud_go_client_test.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/.github/workflows/cloud_nodejs_client_test.yaml
+++ b/.github/workflows/cloud_nodejs_client_test.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -42,7 +42,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Checkout to ${{ github.event.inputs.branch_name }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-nodejs-client
           path: client

--- a/.github/workflows/cloud_python_client_test.yaml
+++ b/.github/workflows/cloud_python_client_test.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -42,7 +42,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           
       - name: Checkout to ${{ github.event.inputs.branch_name }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-python-client
           path: client

--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Checkout to scripts
@@ -53,7 +53,7 @@ jobs:
 
       - name: Checkout to test artifacts
         if: ${{ matrix.kind == 'enterprise' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: hazelcast/private-test-artifacts
           path: certs
@@ -61,7 +61,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Checkout the ${{ github.event.inputs.branch_name }}     
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-cpp-client
           path: client

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -20,12 +20,12 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set server matrix
         id: set-matrix
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -77,7 +77,7 @@ jobs:
           distribution: ${{ steps.java-config.outputs['distribution'] }}
 
       - name: Checkout to ${{ github.event.inputs.branch_name }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-csharp-client
           path: client

--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Checkout to scripts
@@ -54,7 +54,7 @@ jobs:
           go-version: '1.18'
 
       - name: Checkout to test artifacts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: hazelcast/private-test-artifacts
           path: certs
@@ -62,7 +62,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Checkout the ${{ github.event.inputs.branch_name }}     
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-go-client
           path: client

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -20,11 +20,11 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set server matrix
         id: set-matrix
         run: echo "::set-output name=matrix::$( python get_server_matrix.py )"
@@ -42,14 +42,14 @@ jobs:
         uses: actions/checkout@v4
       - name: Checkout to test artifacts
         if: ${{ matrix.kind == 'enterprise' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: hazelcast/private-test-artifacts
           path: certs
           ref: data
           token: ${{ secrets.GH_PAT }}
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Setup Node.js
@@ -70,13 +70,13 @@ jobs:
         run: |
           cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/jars/hazelcast-enterprise-${{ matrix.version }}-tests.jar
       - name: Checkout to master
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-nodejs-client
           path: master
           ref: master
       - name: Checkout to ${{ github.event.inputs.branch_name }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-nodejs-client
           path: client

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -20,11 +20,11 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set server matrix
         id: set-matrix
         run: echo "::set-output name=matrix::$( python get_server_matrix.py )"
@@ -42,14 +42,14 @@ jobs:
         uses: actions/checkout@v4
       - name: Checkout to test artifacts
         if: ${{ matrix.kind == 'enterprise' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: hazelcast/private-test-artifacts
           path: certs
           ref: data
           token: ${{ secrets.GH_PAT }}
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Read Java Config
@@ -66,13 +66,13 @@ jobs:
         run: |
           cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/jars/hazelcast-enterprise-${{ matrix.version }}-tests.jar
       - name: Checkout to master
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-python-client
           path: master
           ref: master
       - name: Checkout to ${{ github.event.inputs.branch_name }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-python-client
           path: client

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -52,14 +52,14 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Checkout to test artifacts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: hazelcast/private-test-artifacts
           path: certs
           ref: data
           token: ${{ secrets.GH_PAT }}
       - name: Checkout to Hazelcast Mono
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-mono
           path: hazelcast-mono
@@ -113,11 +113,11 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set client matrix
         id: set-matrix
         run: echo "::set-output name=matrix::$( python get_client_matrix.py --client py --option tag --use-latest-patch-versions )"
@@ -134,7 +134,7 @@ jobs:
       - name: Checkout to scripts
         uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Read Java Config
@@ -145,13 +145,13 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Checkout to master
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: hazelcast/hazelcast-python-client
           path: master
           ref: master
       - name: Checkout to tag
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: hazelcast/hazelcast-python-client
           path: tag
@@ -214,11 +214,11 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set client matrix
         id: set-matrix
         run: echo "::set-output name=matrix::$( python get_client_matrix.py --client node --option tag --use-latest-patch-versions )"
@@ -234,7 +234,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Setup Node.js
@@ -249,13 +249,13 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Checkout to master
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: hazelcast/hazelcast-nodejs-client
           path: master
           ref: master
       - name: Checkout to tag
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: hazelcast/hazelcast-nodejs-client
           path: tag
@@ -326,11 +326,11 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set client matrix
         id: set-matrix
         run: echo "::set-output name=matrix::$( python get_client_matrix.py --client cs --option tag --use-latest-patch-versions )"
@@ -346,7 +346,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -374,7 +374,7 @@ jobs:
             8.0.x
             
       - name: Checkout to tag
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: hazelcast/hazelcast-csharp-client
           path: tag
@@ -544,11 +544,11 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set client matrix
         id: set-matrix
         run: echo "::set-output name=matrix::$( python get_client_matrix.py --client cpp --option tag --use-latest-patch-versions )"
@@ -564,7 +564,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Read Java Config
@@ -575,12 +575,12 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Checkout master
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: hazelcast/hazelcast-cpp-client
           path: master
       - name: Checkout to tag
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: hazelcast/hazelcast-cpp-client
           path: tag
@@ -663,11 +663,11 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Checkout to scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set client matrix
         id: set-matrix
         run: echo "::set-output name=matrix::$( python get_client_matrix.py --client go --option tag --use-latest-patch-versions )"
@@ -692,7 +692,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
             
       - name: Checkout the ${{ matrix.client_tag }}     
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: hazelcast/hazelcast-go-client
           path: client


### PR DESCRIPTION
[Recent builds](https://github.com/hazelcast/client-compatibility-suites/actions/runs/9872933102) have produced warnings:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-python@v2, actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

Upgrade `checkout` and `setup-python` to the latest versions to resolve.