### PR TITLE
Make server compatibility Maven build quicker

### DIFF
--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -66,7 +66,7 @@ jobs:
           ref: ${{ github.event.inputs.branch_name }}
           token: ${{ secrets.GH_PAT }}
       - name: Build JARs
-        run: mvn clean install -DskipTests=True
+        run: ./mvnw clean install --activate-profiles quick
         working-directory: hazelcast-mono
       - name: Upload Hazelcast JAR
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Using the `quick` profile we can drop the Maven build time from [14 minutes](https://github.com/hazelcast/client-compatibility-suites/actions/runs/9876973263/job/27277425629) to [12 minutes](https://github.com/hazelcast/client-compatibility-suites/actions/runs/9877063468/job/27277738607).