### PR TITLE
Add the java client external & internal kubernetes test

### DIFF
--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -83,6 +83,10 @@ jobs:
         --network=${{env.GCP_NETWORK}} 
         sleep 30
 
+    - name: Set output of cluster_name  
+      id: cluster_name
+      run: echo "::set-output name=cluster_name::${{env.clusterName}}"
+
     - name: Deploy Hazelcast cluster
       run: |-
         helm repo add hazelcast https://hazelcast-charts.s3.amazonaws.com/
@@ -124,9 +128,6 @@ jobs:
     - name: Set output of gke_zone  
       id: gke_zone
       run: echo "::set-output name=gke_zone::${{env.GKE_ZONE}}"
-    - name: Set output of cluster_name  
-      id: cluster_name
-      run: echo "::set-output name=cluster_name::${{env.clusterName}}"
         
   run_go:
     name: Run Go compatibility test

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -9,6 +9,10 @@ on:
         description: Default is hazelcast, but if you would like to run the workflow with your forked repo, set your github username
         required: true
         default: hazelcast
+      java_client_run:
+        description: Java Client (Standard), (old name is Java thin client) = Set the branch name of client to run, otherwise set it as 'no' in order to skip running this client
+        required: true
+        default: develop
       python_run:
         description: PYTHON = Set the branch name of client to run, otherwise set it as 'no' in order to skip running this client
         required: true
@@ -152,6 +156,53 @@ jobs:
         go get github.com/shirou/gopsutil/v3/mem@v3.21.5
         sed -i "s/<EXTERNAL-IP>/${{needs.create-gke-cluster.outputs.external-ip}}/g" main.go
         go run main.go &> output.txt && tail -n 20 output.txt &> last20lines.txt
+        cat last20lines.txt
+        if [ $(grep -o 'Current map size:' last20lines.txt | wc -l) != $"20" ]; then exit 1; fi
+
+  run_java:
+    name: Run Java Client (Standard) compatibility test
+    needs: [create-gke-cluster]
+    if: ${{ github.event.inputs.java_client_run != 'no' }}
+    runs-on: ubuntu-latest
+    
+    steps:  
+    - name: "Setup JRE"
+      uses: "actions/setup-java@v2"
+      with:
+        distribution: "zulu"
+        java-version: "17"
+
+    - name: Checkout to scripts
+      uses: actions/checkout@v4
+        
+    - name: Checkout the java client repo
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.inputs.organization_name }}/hazelcast-java-client
+        path: KubernetesExternalClients/java/clientSourceCode
+        ref: ${{ github.event.inputs.java_client_run }}
+
+    - name: "Setup Local Maven Cache"
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: "Build OS"
+      working-directory: KubernetesExternalClients/java/clientSourceCode
+      run: |
+        chmod +x mvnw
+        HAZELCAST_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        echo "HAZELCAST_VERSION=${HAZELCAST_VERSION}" >> $GITHUB_ENV
+        ./mvnw -B -V -e clean install -DskipTests
+      
+    - name: Run test
+      run: |
+        cd KubernetesExternalClients/java
+        sed -i "s/<EXTERNAL-IP>/${{needs.create-gke-cluster.outputs.external-ip}}/g" src/main/java/KubernetesExternalTest.java
+        mvn exec:java &> output.txt && tail -n 20 output.txt &> last20lines.txt
         cat last20lines.txt
         if [ $(grep -o 'Current map size:' last20lines.txt | wc -l) != $"20" ]; then exit 1; fi
         

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -206,7 +206,7 @@ jobs:
       run: |
         sed -i "s/<EXTERNAL-IP>/${{needs.create-gke-cluster.outputs.external-ip}}/g" src/main/java/KubernetesExternalTest.java
         sed -i "s/java-client-version/$HAZELCAST_VERSION/g" pom.xml
-        mvn clean install
+        mvn clean install -DskipTests
         mvn exec:java 2>&1 | tee output.txt
         tail -n 20 output.txt &> last20lines.txt
         cat last20lines.txt

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -208,9 +208,7 @@ jobs:
         sed -i "s/java-client-version/$HAZELCAST_VERSION/g" pom.xml
         mvn clean install -DskipTests
         mvn -q exec:java 2>&1 | tee output.txt
-        tail -n 20 output.txt &> last20lines.txt
-        cat last20lines.txt
-        if [ $(grep -o 'Current map size:' last20lines.txt | wc -l) != $"20" ]; then exit 1; fi
+        if [ $(grep -o 'KubernetesExternalTest is successful!' output.txt | wc -l) != $"1" ]; then exit 1; fi
         
 #TODO: More reliabe verification
         

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -10,7 +10,7 @@ on:
         required: true
         default: hazelcast
       java_client_run:
-        description: Java Client (Standard), (old name is Java thin client) = Set the branch name of client to run, otherwise set it as 'no' in order to skip running this client
+        description: JAVA = Set the branch name of client to run, otherwise set it as 'no' in order to skip running this client
         required: true
         default: master
       python_run:

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -204,9 +204,8 @@ jobs:
     - name: Run test
       run: |
         cd KubernetesExternalClients/java
-        sed -i "s/<EXTERNAL-IP>/${{needs.create-gke-cluster.outputs.external-ip}}/g" src/main/java/KubernetesExternalTest.java
+        sed -i '' "s/<EXTERNAL-IP>/${{needs.create-gke-cluster.outputs.external-ip}}/g" src/main/java/KubernetesExternalTest.java
         mvn exec:java &> output.txt
-        cat output.txt
         tail -n 20 output.txt &> last20lines.txt
         cat last20lines.txt
         if [ $(grep -o 'Current map size:' last20lines.txt | wc -l) != $"20" ]; then exit 1; fi

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -12,7 +12,7 @@ on:
       java_client_run:
         description: Java Client (Standard), (old name is Java thin client) = Set the branch name of client to run, otherwise set it as 'no' in order to skip running this client
         required: true
-        default: develop
+        default: master
       python_run:
         description: PYTHON = Set the branch name of client to run, otherwise set it as 'no' in order to skip running this client
         required: true

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -181,6 +181,7 @@ jobs:
         repository: ${{ github.event.inputs.organization_name }}/hazelcast-java-client
         path: KubernetesExternalClients/java/clientSourceCode
         ref: ${{ github.event.inputs.java_client_run }}
+        token: ${{ secrets.GH_PAT }}
 
     - name: "Setup Local Maven Cache"
       uses: actions/cache@v4

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -204,8 +204,8 @@ jobs:
     - name: Run test
       working-directory: KubernetesExternalClients/java
       run: |
-        sed -i '' "s/<EXTERNAL-IP>/${{needs.create-gke-cluster.outputs.external-ip}}/g" src/main/java/KubernetesExternalTest.java
-        mvn exec:java &> output.txt
+        sed -i "s/<EXTERNAL-IP>/${{needs.create-gke-cluster.outputs.external-ip}}/g" src/main/java/KubernetesExternalTest.java
+        mvn exec:java 2>&1 | tee output.txt
         tail -n 20 output.txt &> last20lines.txt
         cat last20lines.txt
         if [ $(grep -o 'Current map size:' last20lines.txt | wc -l) != $"20" ]; then exit 1; fi

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -87,6 +87,10 @@ jobs:
       id: cluster_name
       run: echo "::set-output name=cluster_name::${{env.clusterName}}"
 
+    - name: Set output of gke_zone  
+      id: gke_zone
+      run: echo "::set-output name=gke_zone::${{env.GKE_ZONE}}"
+
     - name: Deploy Hazelcast cluster
       run: |-
         helm repo add hazelcast https://hazelcast-charts.s3.amazonaws.com/
@@ -125,9 +129,6 @@ jobs:
     - name: Set output of external-ip
       id: external-ip
       run: echo "::set-output name=external-ip::${{ env.EXTERNAL_IP }}"
-    - name: Set output of gke_zone  
-      id: gke_zone
-      run: echo "::set-output name=gke_zone::${{env.GKE_ZONE}}"
         
   run_go:
     name: Run Go compatibility test

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -205,7 +205,9 @@ jobs:
       run: |
         cd KubernetesExternalClients/java
         sed -i "s/<EXTERNAL-IP>/${{needs.create-gke-cluster.outputs.external-ip}}/g" src/main/java/KubernetesExternalTest.java
-        mvn exec:java &> output.txt && tail -n 20 output.txt &> last20lines.txt
+        mvn exec:java &> output.txt
+        cat output.txt
+        tail -n 20 output.txt &> last20lines.txt
         cat last20lines.txt
         if [ $(grep -o 'Current map size:' last20lines.txt | wc -l) != $"20" ]; then exit 1; fi
         
@@ -366,5 +368,4 @@ jobs:
     - name: Delete cluster
       run: |-
         gcloud container clusters delete ${{ needs.create-gke-cluster.outputs.cluster_name}} --zone=${{ needs.create-gke-cluster.outputs.gke_zone }} --quiet  
-        gcloud container clusters delete kubernetes-clients-compatibility-97 --zone=${{ needs.create-gke-cluster.outputs.gke_zone }} --quiet  
         

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -205,6 +205,7 @@ jobs:
       working-directory: KubernetesExternalClients/java
       run: |
         sed -i "s/<EXTERNAL-IP>/${{needs.create-gke-cluster.outputs.external-ip}}/g" src/main/java/KubernetesExternalTest.java
+        mvn clean install
         mvn exec:java 2>&1 | tee output.txt
         tail -n 20 output.txt &> last20lines.txt
         cat last20lines.txt

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -205,6 +205,7 @@ jobs:
       working-directory: KubernetesExternalClients/java
       run: |
         sed -i "s/<EXTERNAL-IP>/${{needs.create-gke-cluster.outputs.external-ip}}/g" src/main/java/KubernetesExternalTest.java
+        sed -i "s/java-client-version/$HAZELCAST_VERSION/g" pom.xml
         mvn clean install
         mvn exec:java 2>&1 | tee output.txt
         tail -n 20 output.txt &> last20lines.txt

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -202,8 +202,8 @@ jobs:
         ./mvnw -B -V -e clean install -DskipTests
       
     - name: Run test
+      working-directory: KubernetesExternalClients/java
       run: |
-        cd KubernetesExternalClients/java
         sed -i '' "s/<EXTERNAL-IP>/${{needs.create-gke-cluster.outputs.external-ip}}/g" src/main/java/KubernetesExternalTest.java
         mvn exec:java &> output.txt
         tail -n 20 output.txt &> last20lines.txt

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -348,7 +348,7 @@ jobs:
 
   cleanup:
     runs-on: ubuntu-latest
-    needs: [run_nodejs, run_python, run_go, run_cpp, run_csharp, create-gke-cluster]
+    needs: [run_nodejs, run_python, run_go, run_cpp, run_csharp, run_java, create-gke-cluster]
     if: always()
     steps:
     

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -366,3 +366,5 @@ jobs:
     - name: Delete cluster
       run: |-
         gcloud container clusters delete ${{ needs.create-gke-cluster.outputs.cluster_name}} --zone=${{ needs.create-gke-cluster.outputs.gke_zone }} --quiet  
+        gcloud container clusters delete kubernetes-clients-compatibility-97 --zone=${{ needs.create-gke-cluster.outputs.gke_zone }} --quiet  
+        

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -207,7 +207,7 @@ jobs:
         sed -i "s/<EXTERNAL-IP>/${{needs.create-gke-cluster.outputs.external-ip}}/g" src/main/java/KubernetesExternalTest.java
         sed -i "s/java-client-version/$HAZELCAST_VERSION/g" pom.xml
         mvn clean install -DskipTests
-        mvn exec:java 2>&1 | tee output.txt
+        mvn -q exec:java 2>&1 | tee output.txt
         tail -n 20 output.txt &> last20lines.txt
         cat last20lines.txt
         if [ $(grep -o 'Current map size:' last20lines.txt | wc -l) != $"20" ]; then exit 1; fi

--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -65,6 +65,7 @@ jobs:
         working-directory: KubernetesInternalClients/java
         run: |
             sed -i "s/java-client-version/$HAZELCAST_VERSION/g" pom.xml
+            mvn clean install -DskipTests
             docker build -t hazelcast-java-client:test .
     
       - name: Upload image

--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -36,6 +36,12 @@ jobs:
    runs-on: ubuntu-latest
    if: ${{ github.event.inputs.java_client_run != 'no' }}
    steps:
+      - name: "Setup JRE"
+        uses: "actions/setup-java@v2"
+        with:
+          distribution: "zulu"
+          java-version: "17"
+
       - name: Checkout
         uses: actions/checkout@v4
         

--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -6,6 +6,10 @@ on:
         description: Default is hazelcast, but if you would like to run the workflow with your forked repo, set your github username
         required: true
         default: hazelcast
+      java_client_run:
+        description: Java Client (Standard), (old name is Java thin client) = Set the branch name of client to run, otherwise set it as 'no' in order to skip running this client
+        required: true
+        default: master
       python_run:
         description: PYTHON = Set the branch name of client to run, otherwise set it as 'no' in order to skip running this client
         required: true
@@ -28,6 +32,39 @@ on:
         default: master
 
 jobs:
+  create-java-image:
+   runs-on: ubuntu-latest
+   if: ${{ github.event.inputs.java_client_run != 'no' }}
+   steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Checkout the client repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.inputs.organization_name }}/hazelcast-java-client
+          path: KubernetesInternalClients/java/clientSourceCode
+          ref: ${{ github.event.inputs.nodejs_run }}
+          token: ${{ secrets.GH_PAT }}
+          
+      - name: "Build OS"
+        working-directory: KubernetesInternalClients/java/clientSourceCode
+        run: |
+          chmod +x mvnw
+          HAZELCAST_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "HAZELCAST_VERSION=${HAZELCAST_VERSION}" >> $GITHUB_ENV
+          ./mvnw -B -V -e clean install -DskipTests
+    
+      - name: Build client application
+        working-directory: KubernetesInternalClients/java
+        run: |
+            sed -i "s/java-client-version/$HAZELCAST_VERSION/g" pom.xml
+            docker build -t hazelcast-java-client:test .
+    
+      - name: Upload image
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+         image: "hazelcast-java-client:test"
 
   create-csharp-image:
    runs-on: ubuntu-latest
@@ -165,7 +202,7 @@ jobs:
          
   wait-for-images:
     name: Waits for image creation and create json for which clients run
-    needs: [create-python-image, create-nodejs-image, create-go-image, create-csharp-image, create-cpp-image]
+    needs: [create-python-image, create-nodejs-image, create-go-image, create-csharp-image, create-cpp-image, create-java-image]
     if: always()
     runs-on: ubuntu-latest
     outputs:
@@ -178,6 +215,7 @@ jobs:
     - name: Set which client will be run
       id: set-matrix
       run: echo "::set-output name=matrix::$( python set_which_client_run.py
+       --java ${{ github.event.inputs.java_client_run }} 
        --nodejs ${{ github.event.inputs.nodejs_run }}
        --go ${{ github.event.inputs.go_run }}
        --cpp ${{ github.event.inputs.cpp_run }}

--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -7,7 +7,7 @@ on:
         required: true
         default: hazelcast
       java_client_run:
-        description: Java Client (Standard), (old name is Java thin client) = Set the branch name of client to run, otherwise set it as 'no' in order to skip running this client
+        description: JAVA = Set the branch name of client to run, otherwise set it as 'no' in order to skip running this client
         required: true
         default: master
       python_run:

--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.organization_name }}/hazelcast-java-client
           path: KubernetesInternalClients/java/clientSourceCode
-          ref: ${{ github.event.inputs.nodejs_run }}
+          ref: ${{ github.event.inputs.java_client_run }}
           token: ${{ secrets.GH_PAT }}
           
       - name: "Build OS"

--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -315,7 +315,7 @@ jobs:
             kubectl logs --tail=20 hazelcast-${{ matrix.client-language }}-client >> output-${{ matrix.client-language }}-deletepods.txt
             cat output-${{ matrix.client-language }}-deletepods.txt
             if [ $(grep -o 'Current map size:' output-${{ matrix.client-language }}-deletepods.txt | wc -l) != $"20" ]; then exit 1; fi
-            kubectl cp hazelcast-java-client:/log/hazelcast.log .
+            kubectl cp hazelcast-java-client:/log/hazelcast.log hazelcast.log
 
       - name: Upload hazelcast logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -315,7 +315,14 @@ jobs:
             kubectl logs --tail=20 hazelcast-${{ matrix.client-language }}-client >> output-${{ matrix.client-language }}-deletepods.txt
             cat output-${{ matrix.client-language }}-deletepods.txt
             if [ $(grep -o 'Current map size:' output-${{ matrix.client-language }}-deletepods.txt | wc -l) != $"20" ]; then exit 1; fi
-            
+            kubectl cp /log/hazelcast.log .
+
+      - name: Upload hazelcast logs
+        uses: actions/upload-artifact@v4
+        with: 
+          name: hazelcast.log
+          path: hazelcast.log
+
       - name: Logs
         if: always()
         run: |

--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -315,7 +315,7 @@ jobs:
             kubectl logs --tail=20 hazelcast-${{ matrix.client-language }}-client >> output-${{ matrix.client-language }}-deletepods.txt
             cat output-${{ matrix.client-language }}-deletepods.txt
             if [ $(grep -o 'Current map size:' output-${{ matrix.client-language }}-deletepods.txt | wc -l) != $"20" ]; then exit 1; fi
-            kubectl cp pod/hazelcast-java-client:/log/hazelcast.log .
+            kubectl cp hazelcast-java-client:/log/hazelcast.log .
 
       - name: Upload hazelcast logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -315,7 +315,7 @@ jobs:
             kubectl logs --tail=20 hazelcast-${{ matrix.client-language }}-client >> output-${{ matrix.client-language }}-deletepods.txt
             cat output-${{ matrix.client-language }}-deletepods.txt
             if [ $(grep -o 'Current map size:' output-${{ matrix.client-language }}-deletepods.txt | wc -l) != $"20" ]; then exit 1; fi
-            kubectl cp /log/hazelcast.log .
+            kubectl cp pod/hazelcast-java-client:/log/hazelcast.log .
 
       - name: Upload hazelcast logs
         uses: actions/upload-artifact@v4

--- a/KubernetesExternalClients/java/.gitignore
+++ b/KubernetesExternalClients/java/.gitignore
@@ -1,0 +1,38 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/KubernetesExternalClients/java/pom.xml
+++ b/KubernetesExternalClients/java/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.hazelcast</groupId>
+  <artifactId>kubernetes-external-test-java</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>kubernetes-external-test-java</name>
+
+  <properties>
+    <jdk.version>17</jdk.version>
+    <maven.compiler.release>${jdk.version}</maven.compiler.release>
+    <maven.compiler.source>${jdk.version}</maven.compiler.source>
+    <maven.compiler.target>${jdk.version}</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.hazelcast</groupId>
+      <artifactId>hazelcast-enterprise-java-client</artifactId>
+      <version>5.5.1-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.4.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>KubernetesExternalTest</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/KubernetesExternalClients/java/pom.xml
+++ b/KubernetesExternalClients/java/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast-enterprise-java-client</artifactId>
-      <version>5.5.1-SNAPSHOT</version>
+      <version>java-client-version</version>
     </dependency>
   </dependencies>
 

--- a/KubernetesExternalClients/java/pom.xml
+++ b/KubernetesExternalClients/java/pom.xml
@@ -13,11 +13,25 @@
     <maven.compiler.target>${jdk.version}</maven.compiler.target>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>private-repository</id>
+      <name>Hazelcast Private Repository</name>
+      <url>https://repository.hazelcast.com/release/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast-enterprise-java-client</artifactId>
-      <version>java-client-version</version>
+      <version>5.5.1-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
+++ b/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
@@ -39,6 +39,7 @@ public class KubernetesExternalTest {
                 LOGGER.info("Current map size: " + size);
                 Thread.sleep(1000);
             }
+            client.shutdown();
         } catch (Throwable e) {
             LOGGER.severe("Shutting down the client, an error occurred: " + e);
             client.shutdown();

--- a/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
+++ b/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
@@ -1,0 +1,42 @@
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.logging.Logger;
+
+/**
+ * Kubernetes external test for thin java client
+ */
+public class KubernetesExternalTest {
+
+    private static final Logger LOGGER = Logger.getLogger(KubernetesExternalTest.class.getName());
+
+    public static void main( String[] args ) throws InterruptedException {
+        String externalIp = "<EXTERNAL-IP>";
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().addAddress(externalIp);
+
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+        LOGGER.info("Successful connection!");
+
+        IMap<String, String> map =  client.getMap("mapForJava");
+        LOGGER.info("Starting to fill the map with random entries.");
+
+        Random random = ThreadLocalRandom.current();
+        for (int i = 0; i < 120; i++) {
+            int randomKey = random.nextInt(100000);
+            try {
+                map.put("key" + randomKey, "value" + randomKey);
+            } catch (Throwable exc) {
+                LOGGER.warning("Put operation failed: " + exc);
+            }
+            int size = map.size();
+            LOGGER.info("Current map size: " + size);
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
+++ b/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
@@ -24,7 +24,7 @@ public class KubernetesExternalTest {
     }
 
     public static void main( String[] args ) {
-        String externalIp = "127.0.0.1";
+        String externalIp = "<EXTERNAL-IP>";
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().addAddress(externalIp);
@@ -39,7 +39,7 @@ public class KubernetesExternalTest {
             LOGGER.info("Starting to fill the map with random entries.");
 
             Random random = ThreadLocalRandom.current();
-            for (int i = 0; i < 5; i++) {
+            for (int i = 0; i < 120; i++) {
                 int randomKey = random.nextInt(100000);
                 try {
                     map.put("key" + randomKey, "value" + randomKey);

--- a/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
+++ b/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
@@ -28,7 +28,7 @@ public class KubernetesExternalTest {
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().addAddress(externalIp);
-        // disable client logging
+        // disable client logging for test assertion to work properly
         clientConfig.setProperty( "hazelcast.logging.type", "none" );
 
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);

--- a/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
+++ b/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
@@ -28,8 +28,6 @@ public class KubernetesExternalTest {
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().addAddress(externalIp);
-        // disable client logging for test assertion to work properly
-        clientConfig.setProperty( "hazelcast.logging.type", "none" );
 
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
         LOGGER.info("Successful connection!");
@@ -50,6 +48,7 @@ public class KubernetesExternalTest {
                 LOGGER.info("Current map size: " + size);
                 Thread.sleep(1000);
             }
+            LOGGER.info("KubernetesExternalTest is successful!");
             client.shutdown();
         } catch (Throwable e) {
             LOGGER.severe("Shutting down the client, an error occurred: " + e);

--- a/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
+++ b/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
@@ -14,7 +14,7 @@ public class KubernetesExternalTest {
 
     private static final Logger LOGGER = Logger.getLogger(KubernetesExternalTest.class.getName());
 
-    public static void main( String[] args ) throws InterruptedException {
+    public static void main( String[] args ) {
         String externalIp = "<EXTERNAL-IP>";
 
         ClientConfig clientConfig = new ClientConfig();
@@ -23,20 +23,25 @@ public class KubernetesExternalTest {
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
         LOGGER.info("Successful connection!");
 
-        IMap<String, String> map =  client.getMap("mapForJava");
-        LOGGER.info("Starting to fill the map with random entries.");
+        try {
+            IMap<String, String> map =  client.getMap("mapForJava");
+            LOGGER.info("Starting to fill the map with random entries.");
 
-        Random random = ThreadLocalRandom.current();
-        for (int i = 0; i < 120; i++) {
-            int randomKey = random.nextInt(100000);
-            try {
-                map.put("key" + randomKey, "value" + randomKey);
-            } catch (Throwable exc) {
-                LOGGER.warning("Put operation failed: " + exc);
+            Random random = ThreadLocalRandom.current();
+            for (int i = 0; i < 120; i++) {
+                int randomKey = random.nextInt(100000);
+                try {
+                    map.put("key" + randomKey, "value" + randomKey);
+                } catch (Throwable exc) {
+                    LOGGER.warning("Put operation failed: " + exc);
+                }
+                int size = map.size();
+                LOGGER.info("Current map size: " + size);
+                Thread.sleep(1000);
             }
-            int size = map.size();
-            LOGGER.info("Current map size: " + size);
-            Thread.sleep(1000);
+        } catch (Throwable e) {
+            LOGGER.severe("Shutting down the client, an error occurred: " + e);
+            client.shutdown();
         }
     }
 }

--- a/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
+++ b/KubernetesExternalClients/java/src/main/java/KubernetesExternalTest.java
@@ -1,7 +1,9 @@
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
+import com.hazelcast.spi.properties.HazelcastProperty;
 
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
@@ -12,13 +14,22 @@ import java.util.logging.Logger;
  */
 public class KubernetesExternalTest {
 
-    private static final Logger LOGGER = Logger.getLogger(KubernetesExternalTest.class.getName());
+    private static final Logger LOGGER;
+    static {
+        // The following makes jdk logging appear in single lines instead of 2 lines:
+        // https://stackoverflow.com/a/10706033
+        System.setProperty("java.util.logging.SimpleFormatter.format",
+                "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %2$s %5$s%6$s%n");
+        LOGGER = Logger.getLogger(KubernetesExternalTest.class.getName());
+    }
 
     public static void main( String[] args ) {
-        String externalIp = "<EXTERNAL-IP>";
+        String externalIp = "127.0.0.1";
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().addAddress(externalIp);
+        // disable client logging
+        clientConfig.setProperty( "hazelcast.logging.type", "none" );
 
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
         LOGGER.info("Successful connection!");
@@ -28,7 +39,7 @@ public class KubernetesExternalTest {
             LOGGER.info("Starting to fill the map with random entries.");
 
             Random random = ThreadLocalRandom.current();
-            for (int i = 0; i < 120; i++) {
+            for (int i = 0; i < 5; i++) {
                 int randomKey = random.nextInt(100000);
                 try {
                     map.put("key" + randomKey, "value" + randomKey);

--- a/KubernetesInternalClients/java/.gitignore
+++ b/KubernetesInternalClients/java/.gitignore
@@ -1,0 +1,38 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/KubernetesInternalClients/java/Dockerfile
+++ b/KubernetesInternalClients/java/Dockerfile
@@ -1,0 +1,3 @@
+FROM eclipse-temurin:17
+ADD target/uberjar.jar /uberjar.jar
+CMD ["java", "-jar", "/uberjar.jar"]

--- a/KubernetesInternalClients/java/dependency-reduced-pom.xml
+++ b/KubernetesInternalClients/java/dependency-reduced-pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.hazelcast</groupId>
+  <artifactId>kubernetes-internal-test-java</artifactId>
+  <name>kubernetes-internal-test-java</name>
+  <version>1.0-SNAPSHOT</version>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <finalName>uberjar</finalName>
+          <transformers>
+            <transformer>
+              <mainClass>KubernetesInternalTest</mainClass>
+            </transformer>
+          </transformers>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <properties>
+    <maven.compiler.release>${jdk.version}</maven.compiler.release>
+    <maven.compiler.target>${jdk.version}</maven.compiler.target>
+    <maven.compiler.source>${jdk.version}</maven.compiler.source>
+    <jdk.version>17</jdk.version>
+  </properties>
+</project>

--- a/KubernetesInternalClients/java/dependency-reduced-pom.xml
+++ b/KubernetesInternalClients/java/dependency-reduced-pom.xml
@@ -29,6 +29,17 @@
       </plugin>
     </plugins>
   </build>
+  <repositories>
+    <repository>
+      <releases />
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>private-repository</id>
+      <name>Hazelcast Private Repository</name>
+      <url>https://repository.hazelcast.com/release/</url>
+    </repository>
+  </repositories>
   <properties>
     <maven.compiler.release>${jdk.version}</maven.compiler.release>
     <maven.compiler.target>${jdk.version}</maven.compiler.target>

--- a/KubernetesInternalClients/java/pom.xml
+++ b/KubernetesInternalClients/java/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast-enterprise-java-client</artifactId>
-      <version>5.5.1-SNAPSHOT</version>
+      <version>java-client-version</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/KubernetesInternalClients/java/pom.xml
+++ b/KubernetesInternalClients/java/pom.xml
@@ -13,6 +13,20 @@
     <maven.compiler.target>${jdk.version}</maven.compiler.target>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>private-repository</id>
+      <name>Hazelcast Private Repository</name>
+      <url>https://repository.hazelcast.com/release/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>com.hazelcast</groupId>

--- a/KubernetesInternalClients/java/pom.xml
+++ b/KubernetesInternalClients/java/pom.xml
@@ -2,9 +2,9 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.hazelcast</groupId>
-  <artifactId>kubernetes-external-test-java</artifactId>
+  <artifactId>kubernetes-internal-test-java</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <name>kubernetes-external-test-java</name>
+  <name>kubernetes-internal-test-java</name>
 
   <properties>
     <jdk.version>17</jdk.version>
@@ -24,19 +24,25 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.4.1</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
+        <configuration>
+          <finalName>uberjar</finalName>
+          <transformers>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+              <mainClass>KubernetesInternalTest</mainClass>
+            </transformer>
+          </transformers>
+        </configuration>
         <executions>
           <execution>
+            <phase>package</phase>
             <goals>
-              <goal>java</goal>
+              <goal>shade</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <mainClass>KubernetesExternalTest</mainClass>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/KubernetesInternalClients/java/pom.xml
+++ b/KubernetesInternalClients/java/pom.xml
@@ -31,7 +31,17 @@
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast-enterprise-java-client</artifactId>
-      <version>java-client-version</version>
+      <version>5.5.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.23.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.23.1</version>
     </dependency>
   </dependencies>
 

--- a/KubernetesInternalClients/java/src/main/java/KubernetesInternalTest.java
+++ b/KubernetesInternalClients/java/src/main/java/KubernetesInternalTest.java
@@ -27,8 +27,7 @@ public class KubernetesInternalTest {
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().addAddress(internalIp);
-        // disable client logging for test assertion to work properly
-        clientConfig.setProperty( "hazelcast.logging.type", "none" );
+        clientConfig.setProperty( "hazelcast.logging.type", "log4j2" );
 
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
 

--- a/KubernetesInternalClients/java/src/main/java/KubernetesInternalTest.java
+++ b/KubernetesInternalClients/java/src/main/java/KubernetesInternalTest.java
@@ -14,35 +14,42 @@ public class KubernetesInternalTest {
 
     private static final Logger LOGGER = Logger.getLogger(KubernetesInternalTest.class.getName());
 
-    public static void main( String[] args ) throws InterruptedException {
+    public static void main( String[] args ) {
         String internalIp = "hz-hazelcast";
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().addAddress(internalIp);
 
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
-        IMap<String, String> map =  client.getMap("map");
-        map.put("key", "value");
-        String res = map.get("key");
-        if (!res.equals("value")) {
-            LOGGER.warning("Connection failed, check your configuration.");
-        }
-        LOGGER.info("Successful connection!");
-        LOGGER.info("Starting to fill the map with random entries.");
 
-        Random random = ThreadLocalRandom.current();
-        while (true) {
-            int randomKey = random.nextInt(100000);
-            try {
-                map.put("key" + randomKey, "value" + randomKey);
-            } catch (Throwable exc) {
-                LOGGER.warning("Put operation failed: " + exc);
+        try {
+            IMap<String, String> map =  client.getMap("map");
+            map.put("key", "value");
+            String res = map.get("key");
+            if (!res.equals("value")) {
+                LOGGER.warning("Connection failed, check your configuration.");
             }
-            if (randomKey % 100 == 0) {
-                int size = map.size();
-                LOGGER.info("Current map size: " + size);
-                Thread.sleep(1000);
+            LOGGER.info("Successful connection!");
+            LOGGER.info("Starting to fill the map with random entries.");
+
+            Random random = ThreadLocalRandom.current();
+            while (true) {
+                int randomKey = random.nextInt(100000);
+                try {
+                    map.put("key" + randomKey, "value" + randomKey);
+                } catch (Throwable exc) {
+                    LOGGER.warning("Put operation failed: " + exc);
+                }
+                if (randomKey % 100 == 0) {
+                    int size = map.size();
+                    LOGGER.info("Current map size: " + size);
+                    Thread.sleep(1000);
+                }
             }
+        } catch (Throwable e) {
+            LOGGER.severe("An error occurred, shutting down the client: " + e);
+            client.shutdown();
         }
+
     }
 }

--- a/KubernetesInternalClients/java/src/main/java/KubernetesInternalTest.java
+++ b/KubernetesInternalClients/java/src/main/java/KubernetesInternalTest.java
@@ -1,0 +1,48 @@
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.logging.Logger;
+
+/**
+ * Kubernetes internal test for thin java client
+ */
+public class KubernetesInternalTest {
+
+    private static final Logger LOGGER = Logger.getLogger(KubernetesInternalTest.class.getName());
+
+    public static void main( String[] args ) throws InterruptedException {
+        String internalIp = "hz-hazelcast";
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().addAddress(internalIp);
+
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+        IMap<String, String> map =  client.getMap("map");
+        map.put("key", "value");
+        String res = map.get("key");
+        if (!res.equals("value")) {
+            LOGGER.warning("Connection failed, check your configuration.");
+        }
+        LOGGER.info("Successful connection!");
+        LOGGER.info("Starting to fill the map with random entries.");
+
+        Random random = ThreadLocalRandom.current();
+        while (true) {
+            int randomKey = random.nextInt(100000);
+            try {
+                map.put("key" + randomKey, "value" + randomKey);
+            } catch (Throwable exc) {
+                LOGGER.warning("Put operation failed: " + exc);
+            }
+            if (randomKey % 100 == 0) {
+                int size = map.size();
+                LOGGER.info("Current map size: " + size);
+                Thread.sleep(1000);
+            }
+        }
+    }
+}

--- a/KubernetesInternalClients/java/src/main/java/KubernetesInternalTest.java
+++ b/KubernetesInternalClients/java/src/main/java/KubernetesInternalTest.java
@@ -11,14 +11,24 @@ import java.util.logging.Logger;
  * Kubernetes internal test for thin java client
  */
 public class KubernetesInternalTest {
+    private static final Logger LOGGER;
 
-    private static final Logger LOGGER = Logger.getLogger(KubernetesInternalTest.class.getName());
+    static {
+        // The following makes jdk logging appear in single lines instead of 2 lines:
+        // https://stackoverflow.com/a/10706033
+        System.setProperty("java.util.logging.SimpleFormatter.format",
+                "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %2$s %5$s%6$s%n");
+        LOGGER = Logger.getLogger(KubernetesInternalTest.class.getName());
+    }
+
 
     public static void main( String[] args ) {
         String internalIp = "hz-hazelcast";
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().addAddress(internalIp);
+        // disable client logging for test assertion to work properly
+        clientConfig.setProperty( "hazelcast.logging.type", "none" );
 
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
 

--- a/KubernetesInternalClients/java/src/main/resources/log4j2.properties
+++ b/KubernetesInternalClients/java/src/main/resources/log4j2.properties
@@ -1,0 +1,22 @@
+rootLogger.level=info
+property.filepath=log
+property.filename=hazelcast
+
+appenders = file
+
+appender.file.type=RollingFile
+appender.file.name=RollingFile
+appender.file.fileName=${filepath}/${filename}.log
+appender.file.filePattern=${filepath}/${filename}-%d{yyyy-MM-dd}-%i.log.gz
+appender.file.layout.type=PatternLayout
+appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c\{1}:%L - %m%n
+appender.file.policies.type=Policies
+appender.file.policies.time.type=TimeBasedTriggeringPolicy
+appender.file.policies.time.interval=1
+appender.file.policies.time.modulate=true
+appender.file.policies.size.type=SizeBasedTriggeringPolicy
+appender.file.policies.size.size=50MB
+appender.file.strategy.type=DefaultRolloverStrategy
+appender.file.strategy.max=100
+
+rootLogger.appenderRef.file.ref=RollingFile

--- a/set_which_client_run.py
+++ b/set_which_client_run.py
@@ -8,6 +8,11 @@ def parse_arg() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--java",
+        dest="java",
+        type=str,
+    )
+    parser.add_argument(
         "--csharp",
         dest="csharp",
         type=str,
@@ -38,6 +43,8 @@ def parse_arg() -> argparse.Namespace:
 if __name__ == "__main__":
     args = parse_arg()
     options = []
+    if args.java != "no":
+        options.append("java")
     if args.csharp != "no":
         options.append("csharp")
     if args.go != "no":


### PR DESCRIPTION
Adds thin java client tests similar to other tests. Test runs on [thin-client-kubernetes](https://github.com/hazelcast/client-compatibility-suites/tree/thin-client-kubernetes) branch: 

Internal: https://github.com/hazelcast/client-compatibility-suites/actions/runs/10605238016 passed ✅ 
External: https://github.com/hazelcast/client-compatibility-suites/actions/runs/10605726683 passed ✅ 

the code in thin-client-kubernetes branch in this repo is identical to the fork branch (source branch of this PR)