### PR TITLE
Use the v7 license secret for server compat. tests

### DIFF
--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -825,9 +825,14 @@ jobs:
           path: ~/.m2/repository/com/hazelcast/hazelcast-enterprise/${{ needs.upload_jars.outputs.hz_server_version }}
 
       - name: Set up HZ_LICENSEKEY env
-        if: ${{ matrix.server_kind == 'enterprise' }}
+        if: ${{ matrix.server_kind == 'enterprise' && github.event.inputs.hz_version < '5.5' }}
         run: |
           echo "HZ_LICENSEKEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY }}" >> $GITHUB_ENV
+
+      - name: Set up v7 HZ_LICENSEKEY env
+        if: ${{ matrix.server_kind == 'enterprise' && github.event.inputs.hz_version >= '5.5'  }} 
+        run: |
+          echo "HZ_LICENSEKEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}" >> $GITHUB_ENV
 
       - name: Run non-enterprise tests
         run: |


### PR DESCRIPTION
If the server version is >= 5.5, the advanced
ai feature requires the new v7 license. The new
license is not backward compatible.