### PR TITLE
Remove matrix from java compat suites

### DIFF
--- a/.github/workflows/java_client_compatibility.yaml
+++ b/.github/workflows/java_client_compatibility.yaml
@@ -33,28 +33,13 @@ jobs:
 
   test_client:
     needs: [setup_server_matrix]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         server-version: ${{ fromJson(needs.setup_server_matrix.outputs.matrix) }}
         kind: [ os, enterprise ]
-        os: [ ubuntu-latest ]
-        java: [ { version: 17, distribution: corretto },
-                { version: 21, distribution: corretto },
-                { version: 17, distribution: zulu },
-                { version: 21, distribution: zulu },
-                { version: 17, distribution: semeru },
-                { version: 21, distribution: semeru },
-                { version: 17, distribution: oracle },
-                { version: 21, distribution: oracle },
-                { version: 17, distribution: microsoft },
-                { version: 21, distribution: microsoft },
-                { version: 17, distribution: adopt-openj9 },
-                { version: 21, distribution: adopt-openj9 }
-        ]
-
-    name: Test Java client ${{ github.event.inputs.branch_name }} branch against ${{ matrix.kind }} ${{ matrix.server-version }} server on ${{ matrix.os }} and JVM ${{ matrix.java.version }} ${{ matrix.java.distribution }}
+    name: Test Java client ${{ github.event.inputs.branch_name }} branch against ${{ matrix.kind }} ${{ matrix.server-version }} server
     steps:
       - name: Checkout to scripts
         uses: actions/checkout@v4
@@ -62,8 +47,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java.version }}
-          distribution: ${{ matrix.java.distribution }}
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Checkout to ${{ github.event.inputs.branch_name }}
         uses: actions/checkout@v4


### PR DESCRIPTION
Platform does not test compat tests with other jvms. We should not do it as well. It'll consume a lot of resources because ubicloud is not planned for client-compatibility-suites repo. 

There're 96 jobs that some of which takes 4 hours to run, it's not feasible to run that many combinations

see https://github.com/hazelcast/client-compatibility-suites/actions/runs/11034999323
