### PR TITLE
Read environment variables from the config file for Java Client compatibility test [PA-343]

### DIFF
--- a/.github/workflows/java_client_compatibility.yaml
+++ b/.github/workflows/java_client_compatibility.yaml
@@ -44,6 +44,9 @@ jobs:
       - name: Checkout to scripts
         uses: actions/checkout@v4
 
+      - name: Read Java Config
+        run: cat ${{ github.workspace }}/master/.github/java-config.env >> $GITHUB_ENV
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
Read environment variables from the config file and set the environment variables properly. Specifically the `env.JAVA_VERSION` and `env.JAVA_DISTRIBUTION` variables.