### PR TITLE
Upgrade `upload-artifact` from a non-deprecated version

### DIFF
--- a/.github/workflows/cloud_csharp_client_test.yaml
+++ b/.github/workflows/cloud_csharp_client_test.yaml
@@ -88,13 +88,13 @@ jobs:
           ./hz.ps1 -server ${{ github.event.inputs.hzVersion }} test -tf "test == /Hazelcast.Tests.Cloud.ServerlessCloudTests/" -enterprise ${{ secrets.GH_PAT }}
         working-directory: client
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rc
           path: HazelcastCloudTests/dotnethazelcastcloudtests/rc.log
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results

--- a/.github/workflows/cloud_go_client_test.yaml
+++ b/.github/workflows/cloud_go_client_test.yaml
@@ -70,7 +70,7 @@ jobs:
           go test -timeout 2000s -v
         working-directory: HazelcastCloudTests/gohazelcastcloudtests
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rc

--- a/.github/workflows/cloud_nodejs_client_test.yaml
+++ b/.github/workflows/cloud_nodejs_client_test.yaml
@@ -78,7 +78,7 @@ jobs:
           npx mocha cloud_tests.js --exit
         working-directory: HazelcastCloudTests/nodejshazelcastcloudtests
         
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rc

--- a/.github/workflows/cloud_python_client_test.yaml
+++ b/.github/workflows/cloud_python_client_test.yaml
@@ -75,7 +75,7 @@ jobs:
           pytest -o log_cli=true ./cloud_test.py
         working-directory: HazelcastCloudTests/pythonhazelcastcloudtests
         
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: rc


### PR DESCRIPTION
GitHub are now [preventing builds with outdated versions of `upload-artifact` from running](https://github.com/hazelcast/hazelcast-docker/actions/runs/13172853058):
> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

As such upgraded to the latest version.