### PR TITLE
Use dynamic/latest certificates in Python

### DIFF
--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -61,11 +61,6 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Download JARs
         run: python download_server_jars.py --version ${{ matrix.version }} --server-kind ${{ matrix.kind }} --dst jars
-      - name: Copy certificates JAR to destination with the appropriate name
-        if: ${{ matrix.kind == 'enterprise' }}
-        run: |
-          cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/jars/hazelcast-enterprise-${{ matrix.version }}-tests.jar
-          unzip -p $GITHUB_WORKSPACE/certs/certs.jar com/hazelcast/nio/ssl/letsencrypt.jks > tests/integration/backward_compatible/ssl_tests/keystore.jks
       - name: Checkout to master
         uses: actions/checkout@v4
         with:
@@ -82,6 +77,11 @@ jobs:
         run: |
           rm -rf $GITHUB_WORKSPACE/master/hazelcast
           cp -a $GITHUB_WORKSPACE/client/hazelcast $GITHUB_WORKSPACE/master/hazelcast
+      - name: Copy certificates JAR to destination with the appropriate name
+        if: ${{ matrix.kind == 'enterprise' }}
+        run: |
+          cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/jars/hazelcast-enterprise-${{ matrix.version }}-tests.jar
+          unzip -p $GITHUB_WORKSPACE/certs/certs.jar com/hazelcast/nio/ssl/letsencrypt.jks > master/tests/integration/backward_compatible/ssl_tests/keystore.jks
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -65,6 +65,7 @@ jobs:
         if: ${{ matrix.kind == 'enterprise' }}
         run: |
           cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/jars/hazelcast-enterprise-${{ matrix.version }}-tests.jar
+          unzip -p $GITHUB_WORKSPACE/certs/certs.jar com/hazelcast/nio/ssl/letsencrypt.jks > tests/integration/backward_compatible/ssl_tests/keystore.jks
       - name: Checkout to master
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Outdated certificates caused a [test failure](https://github.com/hazelcast/client-compatibility-suites/actions/runs/14998179569/job/42138824244).

There was [an action](https://github.com/hazelcast/hazelcast-python-client/actions/runs/14766960347/workflow) to update these automatically in the repo, but due to new branch protection [it's failing](https://github.com/hazelcast/hazelcast-python-client/actions/runs/14766960347/job/41460207509).

Rather than update the source code, we can simply hot-replace the certificates before we test as per https://github.com/hazelcast/hazelcast-nodejs-client/pull/1535.

[Example execution](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15025997762).

Post-merge actions:
- [ ] disable [the action](https://github.com/hazelcast/hazelcast-python-client/actions/runs/14766960347/workflow)