### PR TITLE
Centralise setting license

### DIFF
--- a/.github/actions/get-enterprise-license/action.yml
+++ b/.github/actions/get-enterprise-license/action.yml
@@ -1,4 +1,4 @@
-name: Get an the key of a secret for a appropriate Hazelcast Enterprise license for specified version
+name: Get the name/key of a secret to use to lookup an appropriate Hazelcast Enterprise license for a specified version
 inputs:
   hazelcast-version:
     description: Hazelcast version to get a license for

--- a/.github/actions/get-enterprise-license/action.yml
+++ b/.github/actions/get-enterprise-license/action.yml
@@ -1,4 +1,4 @@
-name: Get an appropriate Hazelcast Enterprise license for specified version
+name: Get an the key of a secret for a appropriate Hazelcast Enterprise license for specified version
 inputs:
   hazelcast-version:
     description: Hazelcast version to get a license for

--- a/.github/actions/get-enterprise-license/action.yml
+++ b/.github/actions/get-enterprise-license/action.yml
@@ -1,0 +1,44 @@
+name: Get an appropriate Hazelcast Enterprise license for specified version
+inputs:
+  hazelcast-version:
+    description: Hazelcast version to get a license for
+    required: true
+outputs:
+  HAZELCAST_ENTERPRISE_KEY_SECRET:
+    value: ${{ steps.get-license.outputs.secret-key }}
+    description: The name of the secret key to use to lookup the license (not the license itself as not accessible to composite action)
+runs:
+  using: "composite"
+  steps:
+    # https://github.com/madhead/semver-utils/releases/tag/v4.3.0
+    - uses: madhead/semver-utils@36d1e0ed361bd7b4b77665de8093092eaeabe6ba
+      id: version-5-3
+      with:
+        version: ${{ inputs.hazelcast-version }}
+        compare-to: 5.3.0
+
+    # https://github.com/madhead/semver-utils/releases/tag/v4.3.0
+    - uses: madhead/semver-utils@36d1e0ed361bd7b4b77665de8093092eaeabe6ba
+      id: version-5-5
+      with:
+        version: ${{ inputs.hazelcast-version }}
+        compare-to: 5.5.0
+
+    - name: Determine best license version
+      shell: bash
+      id: get-license
+      run: |
+        # < 5.3           -> HAZELCAST_ENTERPRISE_KEY_V5
+        # >= 5.3 && < 5.5 -> HAZELCAST_ENTERPRISE_KEY
+        # >= 5.5          -> HAZELCAST_ENTERPRISE_KEY_V7
+
+        if [[ "${{ steps.version-5-3.outputs.comparison-result }}" = "<" ]]; then
+          echo "::debug::< 5.3"
+          echo "secret-key=HAZELCAST_ENTERPRISE_KEY_V5" >> ${GITHUB_OUTPUT}
+        elif [[ "${{ steps.version-5-5.outputs.comparison-result }}" == "<" ]]; then
+          echo "::debug::>= 5.3 && < 5.5"
+          echo "secret-key=HAZELCAST_ENTERPRISE_KEY" >> ${GITHUB_OUTPUT}
+        else
+          echo "::debug::>= 5.5"
+          echo "secret-key=HAZELCAST_ENTERPRISE_KEY_V7" >> ${GITHUB_OUTPUT}
+        fi

--- a/.github/workflows/cloud_csharp_client_test.yaml
+++ b/.github/workflows/cloud_csharp_client_test.yaml
@@ -88,7 +88,7 @@ jobs:
           HZ_VERSION: ${{ github.event.inputs.hzVersion }}
           HZ_CLOUD_COORDINATOR_BASE_URL: ${{ github.event.inputs.base_url }}
           HAZELCAST_SERVER_VERSION: ${{ github.event.inputs.hzVersion }}
-          HAZELCAST_ENTERPRISE_KEY: ${{ steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}
         run: |
           ./hz.ps1 -server ${{ github.event.inputs.hzVersion }} test -tf "test == /Hazelcast.Tests.Cloud.ServerlessCloudTests/" -enterprise ${{ secrets.GH_PAT }}
         working-directory: client

--- a/.github/workflows/cloud_csharp_client_test.yaml
+++ b/.github/workflows/cloud_csharp_client_test.yaml
@@ -74,6 +74,11 @@ jobs:
           sleep 30
         working-directory: HazelcastCloudTests/dotnethazelcastcloudtests
        
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+        id: get-enterprise-license
+        with:
+          hazelcast-version: ${{ github.event.inputs.hzVersion }}
+
       - name: Run cloud tests
         shell: pwsh
         env:
@@ -83,7 +88,7 @@ jobs:
           HZ_VERSION: ${{ github.event.inputs.hzVersion }}
           HZ_CLOUD_COORDINATOR_BASE_URL: ${{ github.event.inputs.base_url }}
           HAZELCAST_SERVER_VERSION: ${{ github.event.inputs.hzVersion }}
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}
         run: |
           ./hz.ps1 -server ${{ github.event.inputs.hzVersion }} test -tf "test == /Hazelcast.Tests.Cloud.ServerlessCloudTests/" -enterprise ${{ secrets.GH_PAT }}
         working-directory: client

--- a/.github/workflows/cloud_csharp_client_test.yaml
+++ b/.github/workflows/cloud_csharp_client_test.yaml
@@ -74,7 +74,7 @@ jobs:
           sleep 30
         working-directory: HazelcastCloudTests/dotnethazelcastcloudtests
        
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hzVersion }}

--- a/.github/workflows/cloud_csharp_client_test.yaml
+++ b/.github/workflows/cloud_csharp_client_test.yaml
@@ -74,7 +74,7 @@ jobs:
           sleep 30
         working-directory: HazelcastCloudTests/dotnethazelcastcloudtests
        
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
+      - uses: ./.github/actions/get-enterprise-license
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hzVersion }}

--- a/.github/workflows/cloud_csharp_client_test.yaml
+++ b/.github/workflows/cloud_csharp_client_test.yaml
@@ -88,7 +88,7 @@ jobs:
           HZ_VERSION: ${{ github.event.inputs.hzVersion }}
           HZ_CLOUD_COORDINATOR_BASE_URL: ${{ github.event.inputs.base_url }}
           HAZELCAST_SERVER_VERSION: ${{ github.event.inputs.hzVersion }}
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY }}
         run: |
           ./hz.ps1 -server ${{ github.event.inputs.hzVersion }} test -tf "test == /Hazelcast.Tests.Cloud.ServerlessCloudTests/" -enterprise ${{ secrets.GH_PAT }}
         working-directory: client

--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -100,10 +100,15 @@ jobs:
         run: |
           cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/client/hazelcast-enterprise-${{ matrix.version }}-tests.jar
 
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+        id: get-enterprise-license
+        with:
+          hazelcast-version: ${{ matrix.version }}
+
       - name: Test
         env:
           BUILD_DIR: build
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}
           GTEST_FILTER: -*Aws*:*DescribeInstancesTest*
           HZ_VERSION: ${{ matrix.version }}
         run: |

--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -100,7 +100,7 @@ jobs:
         run: |
           cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/client/hazelcast-enterprise-${{ matrix.version }}-tests.jar
 
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ matrix.version }}

--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -40,6 +40,8 @@ jobs:
         
     name: Test Cpp client against ${{ matrix.kind }} ${{ matrix.version }} server on ubuntu-latest
     steps:
+      - name: Checkout to scripts
+        uses: actions/checkout@v4
         
       - name: Read Java Config
         run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
@@ -100,7 +102,7 @@ jobs:
         run: |
           cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/client/hazelcast-enterprise-${{ matrix.version }}-tests.jar
 
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
+      - uses: ./.github/actions/get-enterprise-license
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ matrix.version }}

--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Test
         env:
           BUILD_DIR: build
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}
           GTEST_FILTER: -*Aws*:*DescribeInstancesTest*
           HZ_VERSION: ${{ matrix.version }}
         run: |

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -94,7 +94,7 @@ jobs:
         env:
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}      
         
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ matrix.version }}

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -57,13 +57,6 @@ jobs:
           dotnet-version: |
             8.0.x
 
-      - uses: madhead/semver-utils@latest
-        name: Check Server Version to Determine License Version
-        id: version
-        with:
-          version: ${{ matrix.version }}
-          compare-to: 5.3.0
-            
       - name: Read Java Config
         uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
@@ -101,13 +94,18 @@ jobs:
         env:
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}      
         
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+        id: get-enterprise-license
+        with:
+          hazelcast-version: ${{ matrix.version }}
+
       - name: Run all tests        
         shell: pwsh
         if: ${{ matrix.kind == 'enterprise' }}
         run: ./hz.ps1 -enterprise -noRestore -localRestore -server ${{ matrix.version }} test ${{ secrets.GH_PAT }}
         working-directory: client        
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ '>' == steps.version.outputs.comparison-result && secrets.HAZELCAST_ENTERPRISE_KEY || secrets.HAZELCAST_ENTERPRISE_KEY_V5 }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}
 
           

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -105,7 +105,7 @@ jobs:
         run: ./hz.ps1 -enterprise -noRestore -localRestore -server ${{ matrix.version }} test ${{ secrets.GH_PAT }}
         working-directory: client        
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}
 
           

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -94,7 +94,7 @@ jobs:
         env:
           HAZELCAST_SERVER_VERSION: ${{ matrix.version }}      
         
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
+      - uses: ./.github/actions/get-enterprise-license
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ matrix.version }}

--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -74,9 +74,14 @@ jobs:
         run: |
           cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/client/hazelcast-enterprise-${{ matrix.version }}-tests.jar
 
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+        id: get-enterprise-license
+        with:
+          hazelcast-version: ${{ matrix.version }}
+
       - name: Test
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}
           HZ_VERSION: ${{ matrix.version }}
           SSL_ENABLED: 1
         run: |

--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/client/hazelcast-enterprise-${{ matrix.version }}-tests.jar
 
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ matrix.version }}

--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Test
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}
           HZ_VERSION: ${{ matrix.version }}
           SSL_ENABLED: 1
         run: |

--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/client/hazelcast-enterprise-${{ matrix.version }}-tests.jar
 
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
+      - uses: ./.github/actions/get-enterprise-license
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ matrix.version }}

--- a/.github/workflows/java_client_compatibility.yaml
+++ b/.github/workflows/java_client_compatibility.yaml
@@ -88,7 +88,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ matrix.version }}

--- a/.github/workflows/java_client_compatibility.yaml
+++ b/.github/workflows/java_client_compatibility.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Set up HZ_LICENSEKEY env
         if: ${{ matrix.server_kind == 'enterprise' }}
         run: |
-          echo "HZ_LICENSEKEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
+          echo "HZ_LICENSEKEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> ${GITHUB_ENV}
 
       - name: Build modules
         shell: bash -l {0}

--- a/.github/workflows/java_client_compatibility.yaml
+++ b/.github/workflows/java_client_compatibility.yaml
@@ -88,17 +88,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check Server Version to Determine License Version
-        uses: madhead/semver-utils@latest
-        id: version
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+        id: get-enterprise-license
         with:
-          version: ${{ matrix.server_version }}
-          compare-to: 5.3.0
+          hazelcast-version: ${{ matrix.version }}
 
       - name: Set up HZ_LICENSEKEY env
         if: ${{ matrix.server_kind == 'enterprise' }}
         run: |
-          echo "HZ_LICENSEKEY=${{ '>' == steps.version.outputs.comparison-result && secrets.HAZELCAST_ENTERPRISE_KEY || secrets.HAZELCAST_ENTERPRISE_KEY_V5 }}" >> $GITHUB_ENV
+          echo "HZ_LICENSEKEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
 
       - name: Build modules
         shell: bash -l {0}

--- a/.github/workflows/java_client_compatibility.yaml
+++ b/.github/workflows/java_client_compatibility.yaml
@@ -88,7 +88,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
+      - uses: ./.github/actions/get-enterprise-license
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ matrix.version }}

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -96,9 +96,13 @@ jobs:
           rm $GITHUB_WORKSPACE/master/package.json
           cp -a $GITHUB_WORKSPACE/client/lib $GITHUB_WORKSPACE/master/lib
           cp -a $GITHUB_WORKSPACE/client/package.json $GITHUB_WORKSPACE/master/package.json
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+        id: get-enterprise-license
+        with:
+          hazelcast-version: ${{ matrix.version }}
       - name: Start RC
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.kind }}
       - name: Run non-enterprise tests
         if: ${{ matrix.kind == 'os' }}
@@ -109,4 +113,4 @@ jobs:
         run: node node_modules/mocha/bin/mocha --recursive test/integration/backward_compatible
         working-directory: master
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -96,7 +96,7 @@ jobs:
           rm $GITHUB_WORKSPACE/master/package.json
           cp -a $GITHUB_WORKSPACE/client/lib $GITHUB_WORKSPACE/master/lib
           cp -a $GITHUB_WORKSPACE/client/package.json $GITHUB_WORKSPACE/master/package.json
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
+      - uses: ./.github/actions/get-enterprise-license
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ matrix.version }}

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -102,7 +102,7 @@ jobs:
           hazelcast-version: ${{ matrix.version }}
       - name: Start RC
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.kind }}
       - name: Run non-enterprise tests
         if: ${{ matrix.kind == 'os' }}
@@ -113,4 +113,4 @@ jobs:
         run: node node_modules/mocha/bin/mocha --recursive test/integration/backward_compatible
         working-directory: master
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -96,7 +96,7 @@ jobs:
           rm $GITHUB_WORKSPACE/master/package.json
           cp -a $GITHUB_WORKSPACE/client/lib $GITHUB_WORKSPACE/master/lib
           cp -a $GITHUB_WORKSPACE/client/package.json $GITHUB_WORKSPACE/master/package.json
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ matrix.version }}

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -92,7 +92,7 @@ jobs:
           hazelcast-version: ${{ matrix.version }}
       - name: Start RC
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.kind }} --use-simple-server
       - name: Run non-enterprise tests
         if: ${{ matrix.kind == 'os' }}

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -86,7 +86,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-test.txt
         working-directory: master
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ matrix.version }}

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -86,7 +86,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-test.txt
         working-directory: master
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
+      - uses: ./.github/actions/get-enterprise-license
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ matrix.version }}

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -86,15 +86,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-test.txt
         working-directory: master
-      - name: Check Server Version to Determine License Version
-        uses: madhead/semver-utils@v4.3.0
-        id: version
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+        id: get-enterprise-license
         with:
-          version: ${{ matrix.version }}
-          compare-to: 5.3.0
+          hazelcast-version: ${{ matrix.version }}
       - name: Start RC
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ '>' == steps.version.outputs.comparison-result && secrets.HAZELCAST_ENTERPRISE_KEY_V7 || secrets.HAZELCAST_ENTERPRISE_KEY_V5 }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.kind }} --use-simple-server
       - name: Run non-enterprise tests
         if: ${{ matrix.kind == 'os' }}

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -147,7 +147,7 @@ jobs:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
         run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
+          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> ${GITHUB_ENV}
       - name: Checkout to scripts
         uses: actions/checkout@v4
       - name: Setup Python
@@ -253,7 +253,7 @@ jobs:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
         run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
+          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> ${GITHUB_ENV}
 
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -370,7 +370,7 @@ jobs:
       - name: Set up enterprise license key
         shell: pwsh
         run: |
-          "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> $env:GITHUB_ENV
+          "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> $env:GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -591,7 +591,7 @@ jobs:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
         run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
+          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> ${GITHUB_ENV}
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -715,7 +715,7 @@ jobs:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
         run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
+          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> ${GITHUB_ENV}
       - uses: actions/checkout@v4
       - name: Read Java Config
         run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
@@ -804,7 +804,7 @@ jobs:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
         run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
+          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> ${GITHUB_ENV}
       - uses: actions/checkout@v4
       - name: Read Java Config
         run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
@@ -888,7 +888,7 @@ jobs:
       - name: Set up HZ_LICENSEKEY env
         if: ${{ matrix.server_kind == 'enterprise' }}
         run: |
-          echo "HZ_LICENSEKEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
+          echo "HZ_LICENSEKEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> ${GITHUB_ENV}
 
       - name: Build modules
         shell: bash -l {0}

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -141,14 +141,13 @@ jobs:
         server_kind: [ os, enterprise ]
     name: Test Python client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+        id: get-enterprise-license
+        with:
+          hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
-        if: ${{ github.event.inputs.hz_version < '5.5' }}
         run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY }}" >> $GITHUB_ENV
-      - name: Set up enterprise v7 license key
-        if: ${{ github.event.inputs.hz_version >= '5.5' }}
-        run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}" >> $GITHUB_ENV
+          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
       - name: Checkout to scripts
         uses: actions/checkout@v4
       - name: Setup Python
@@ -213,8 +212,6 @@ jobs:
           name: hazelcast-enterprise-tests
           path: jars
       - name: Start RC
-        env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ env.HAZELCAST_ENTERPRISE_KEY }}
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.server_kind }} --use-simple-server
       - name: Run non-enterprise tests
         if: ${{ matrix.server_kind == 'os' }}
@@ -250,14 +247,14 @@ jobs:
         server_kind: [ os, enterprise ]
     name: Test Node.js client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+        id: get-enterprise-license
+        with:
+          hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
-        if: ${{ github.event.inputs.hz_version < '5.5' }}
         run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY }}" >> $GITHUB_ENV
-      - name: Set up enterprise v7 license key
-        if: ${{ github.event.inputs.hz_version >= '5.5' }}
-        run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}" >> $GITHUB_ENV
+          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
+
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -331,8 +328,6 @@ jobs:
           name: hazelcast-enterprise-tests
           path: jars
       - name: Start RC
-        env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ env.HAZELCAST_ENTERPRISE_KEY }}
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.server_kind }}
       - name: Run non-enterprise tests
         if: ${{ matrix.server_kind == 'os' }}
@@ -342,8 +337,6 @@ jobs:
         if: ${{ matrix.server_kind == 'enterprise' }}
         run: node node_modules/mocha/bin/mocha --recursive test/integration/backward_compatible
         working-directory: master
-        env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ env.HAZELCAST_ENTERPRISE_KEY }}
   setup_csharp_client_matrix:
     name: Setup the Csharp client test matrix
     if: ${{ github.event.inputs.run_csharp == 'run' }}
@@ -370,16 +363,14 @@ jobs:
         server_kind: [ os, enterprise ]
     name: Test Csharp client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+        id: get-enterprise-license
+        with:
+          hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
         shell: pwsh
-        if: ${{ github.event.inputs.hz_version < '5.5' }}
         run: |
-          "HAZELCAST_ENTERPRISE_KEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY }}" >> $env:GITHUB_ENV
-      - name: Set up enterprise v7 license key
-        shell: pwsh
-        if: ${{ github.event.inputs.hz_version >= '5.5' }}
-        run: |
-          "HAZELCAST_ENTERPRISE_KEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}" >> $env:GITHUB_ENV
+          "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> $env:GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -471,16 +462,15 @@ jobs:
           $client = "${{matrix.client_tag}}".replace("v","")
           "CLIENT_VERSION=$client" >> $env:GITHUB_ENV
 
-      - uses: madhead/semver-utils@latest
-        id: version
+      # https://github.com/madhead/semver-utils/releases/tag/v4.3.0
+      - uses: madhead/semver-utils@36d1e0ed361bd7b4b77665de8093092eaeabe6ba
+        id: client-version
         with:
           version: ${{ env.CLIENT_VERSION }}
-          compare-to: 5.2.x
-          satisfies: x
       
       - name: Client Version
         run: |
-          echo "${{steps.version.outputs.major}}.${{steps.version.outputs.minor }}.${{steps.version.outputs.patch }}"
+          echo "${{steps.client-version.outputs.major}}.${{steps.client-version.outputs.minor }}.${{steps.client-version.outputs.patch }}"
 
       - name: Copy latest build scripts to local workspace
         shell: pwsh
@@ -492,7 +482,7 @@ jobs:
 
       - name: Backport SSL Tests
         id: backport-tests
-        if: ${{  ((steps.version.outputs.major == '5' && steps.version.outputs.minor < '3') || (steps.version.outputs.major == '4')) }}
+        if: ${{  ((steps.client-version.outputs.major == '5' && steps.client-version.outputs.minor < '3') || (steps.client-version.outputs.major == '4')) }}
         shell: pwsh
         working-directory: tag
         run: |
@@ -500,7 +490,7 @@ jobs:
 
       - name: Upgrade NUnit Adapter in Testing if Client v5.2.2 or v5.3.1
         id: upgrade-nunit-adapter
-        if: ${{  ((steps.version.outputs.major == '5' && steps.version.outputs.minor == '3' &&  steps.version.outputs.patch == '1') || (steps.version.outputs.major == '5' && steps.version.outputs.minor == '2' &&  steps.version.outputs.patch == '2')) }}
+        if: ${{  ((steps.client-version.outputs.major == '5' && steps.client-version.outputs.minor == '3' &&  steps.client-version.outputs.patch == '1') || (steps.client-version.outputs.major == '5' && steps.client-version.outputs.minor == '2' &&  steps.client-version.outputs.patch == '2')) }}
         working-directory: tag
         run: |
           sed -i 's/<PackageReference Include="NUnit3TestAdapter" Version="4.3.1">/<PackageReference Include="NUnit3TestAdapter" Version="4.5.0">/g' src/Hazelcast.Net.Tests/Hazelcast.Net.Tests.csproj
@@ -512,7 +502,7 @@ jobs:
           ./hz.ps1 clean, build
 
       - name: Build Client 4.0.2 with compatibility
-        if: ${{ steps.version.outputs.major == '4' && steps.version.outputs.minor == '0'  }}
+        if: ${{ steps.client-version.outputs.major == '4' && steps.client-version.outputs.minor == '0'  }}
         shell: pwsh
         working-directory: tag 
         run: |
@@ -547,7 +537,6 @@ jobs:
            ./hz.ps1 -enterprise -tf "method != SendReceive" -server ${{ github.event.inputs.hz_version }}-SNAPSHOT test ${{ secrets.GH_PAT }}
         working-directory: tag
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ env.HAZELCAST_ENTERPRISE_KEY }}
           HAZELCAST_SERVER_VERSION: ${{ github.event.inputs.hz_version }}
           HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
           HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
@@ -559,7 +548,6 @@ jobs:
            ./hz.ps1 -enterprise -tf "method != SendReceive" -server ${{ github.event.inputs.hz_version }}-SNAPSHOT test ${{ secrets.GH_PAT }}
         working-directory: tag
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ env.HAZELCAST_ENTERPRISE_KEY }}
           HAZELCAST_SERVER_VERSION: ${{ github.event.inputs.hz_version }} 
           HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
           HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
@@ -597,14 +585,13 @@ jobs:
         server_kind: [ enterprise ] #TODO When tests are divided as OS, ENTERPRISE, OS matrix will be added
     name: Test CPP client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+        id: get-enterprise-license
+        with:
+          hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
-        if: ${{ github.event.inputs.hz_version < '5.5' }}
         run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY }}" >> $GITHUB_ENV
-      - name: Set up enterprise v7 license key
-        if: ${{ github.event.inputs.hz_version >= '5.5' }}
-        run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}" >> $GITHUB_ENV
+          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -688,7 +675,6 @@ jobs:
       - name: Test
         env:
           BUILD_DIR: build
-          HAZELCAST_ENTERPRISE_KEY: ${{ env.HAZELCAST_ENTERPRISE_KEY }}
           GTEST_FILTER: -*Aws*:*DescribeInstancesTest*
           HZ_VERSION: '${{ github.event.inputs.hz_version }}-SNAPSHOT'
         run: |
@@ -723,14 +709,13 @@ jobs:
         
     name: Test Go client ${{ matrix.client_tag }} with enterprise server on ubuntu-latest
     steps:
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+        id: get-enterprise-license
+        with:
+          hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
-        if: ${{ github.event.inputs.hz_version < '5.5' }}
         run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY }}" >> $GITHUB_ENV
-      - name: Set up enterprise v7 license key
-        if: ${{ github.event.inputs.hz_version >= '5.5' }}
-        run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}" >> $GITHUB_ENV
+          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
       - uses: actions/checkout@v4
       - name: Read Java Config
         run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
@@ -776,7 +761,6 @@ jobs:
           
       - name: Test
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ env.HAZELCAST_ENTERPRISE_KEY }}
           HZ_VERSION: '${{ github.event.inputs.hz_version }}-SNAPSHOT'
           SSL_ENABLED: 1
         run: |
@@ -814,14 +798,13 @@ jobs:
             tests_type: enterprise
     name: Test Java client (standalone) ${{ matrix.client_tag }} branch running ${{ matrix.tests_type }} tests against ${{ matrix.server_kind }} server
     steps:
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+        id: get-enterprise-license
+        with:
+          hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
-        if: ${{ github.event.inputs.hz_version < '5.5' }}
         run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY }}" >> $GITHUB_ENV
-      - name: Set up enterprise v7 license key
-        if: ${{ github.event.inputs.hz_version >= '5.5' }}
-        run: |
-          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}" >> $GITHUB_ENV
+          echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
       - uses: actions/checkout@v4
       - name: Read Java Config
         run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
@@ -903,14 +886,9 @@ jobs:
            -DgeneratePom=true
 
       - name: Set up HZ_LICENSEKEY env
-        if: ${{ matrix.server_kind == 'enterprise' && needs.upload_jars.outputs.hz_server_version < '5.5' }}
+        if: ${{ matrix.server_kind == 'enterprise' }}
         run: |
-          echo "HZ_LICENSEKEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY }}" >> $GITHUB_ENV
-
-      - name: Set up v7 HZ_LICENSEKEY env
-        if: ${{ matrix.server_kind == 'enterprise' && needs.upload_jars.outputs.hz_server_version >= '5.5'  }}
-        run: |
-          echo "HZ_LICENSEKEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}" >> $GITHUB_ENV
+          echo "HZ_LICENSEKEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY] }}" >> ${GITHUB_ENV}
 
       - name: Build modules
         shell: bash -l {0}

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -141,7 +141,7 @@ jobs:
         server_kind: [ os, enterprise ]
     name: Test Python client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
@@ -247,7 +247,7 @@ jobs:
         server_kind: [ os, enterprise ]
     name: Test Node.js client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
@@ -363,7 +363,7 @@ jobs:
         server_kind: [ os, enterprise ]
     name: Test Csharp client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
@@ -585,7 +585,7 @@ jobs:
         server_kind: [ enterprise ] #TODO When tests are divided as OS, ENTERPRISE, OS matrix will be added
     name: Test CPP client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
@@ -709,7 +709,7 @@ jobs:
         
     name: Test Go client ${{ matrix.client_tag }} with enterprise server on ubuntu-latest
     steps:
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
@@ -798,7 +798,7 @@ jobs:
             tests_type: enterprise
     name: Test Java client (standalone) ${{ matrix.client_tag }} branch running ${{ matrix.tests_type }} tests against ${{ matrix.server_kind }} server
     steps:
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license
+      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hz_version }}

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -141,15 +141,15 @@ jobs:
         server_kind: [ os, enterprise ]
     name: Test Python client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
+      - name: Checkout to scripts
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/get-enterprise-license
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
         run: |
           echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> ${GITHUB_ENV}
-      - name: Checkout to scripts
-        uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -247,15 +247,14 @@ jobs:
         server_kind: [ os, enterprise ]
     name: Test Node.js client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/get-enterprise-license
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
         run: |
           echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> ${GITHUB_ENV}
-
-      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -363,7 +362,8 @@ jobs:
         server_kind: [ os, enterprise ]
     name: Test Csharp client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/get-enterprise-license
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
@@ -371,7 +371,6 @@ jobs:
         shell: pwsh
         run: |
           "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> $env:GITHUB_ENV
-      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -585,14 +584,14 @@ jobs:
         server_kind: [ enterprise ] #TODO When tests are divided as OS, ENTERPRISE, OS matrix will be added
     name: Test CPP client ${{ matrix.client_tag }} with ${{ matrix.server_kind }} server
     steps:
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/get-enterprise-license
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
         run: |
           echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> ${GITHUB_ENV}
-      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -709,14 +708,14 @@ jobs:
         
     name: Test Go client ${{ matrix.client_tag }} with enterprise server on ubuntu-latest
     steps:
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/get-enterprise-license
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
         run: |
           echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> ${GITHUB_ENV}
-      - uses: actions/checkout@v4
       - name: Read Java Config
         run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
       - name: Setup Java
@@ -798,14 +797,14 @@ jobs:
             tests_type: enterprise
     name: Test Java client (standalone) ${{ matrix.client_tag }} branch running ${{ matrix.tests_type }} tests against ${{ matrix.server_kind }} server
     steps:
-      - uses: hazelcast/client-compatibility-suites/.github/actions/get-enterprise-license@master
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/get-enterprise-license
         id: get-enterprise-license
         with:
           hazelcast-version: ${{ github.event.inputs.hz_version }}
       - name: Set up enterprise license key
         run: |
           echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> ${GITHUB_ENV}
-      - uses: actions/checkout@v4
       - name: Read Java Config
         run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
 


### PR DESCRIPTION
Different version of Hazelcast platform need different formats of license keys to unlock various features.

The logic around which version requires which license is duplicated and in any case is missing the full range of cases, causing test failures.

This PR:
- centralises setting the enterprise license key logic
- refactors everything to use it
- ensures all three cases of license are handled
- sets the `madhead/semver-utils` version by SHA as per GitHub security guidelines
   - they were already conflicting _anyway_ so I had to pick something

Example [compatibility-tests execution](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15062951610), test output of just the `get-enterprise-license` bit [here](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15048990999/job/42298742357).

Fixes: https://github.com/hazelcast/client-compatibility-suites/issues/156
Closes: https://github.com/hazelcast/client-compatibility-suites/pull/157 (alternative implementation)