### PR TITLE
Revert "Revert reading from github env for csharp client"

### DIFF
--- a/.github/java-config.yml
+++ b/.github/java-config.yml
@@ -1,2 +1,0 @@
-java-version: "17"	
-distribution: "temurin"	

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -58,16 +58,14 @@ jobs:
             8.0.x
 
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
-        id: java-config
-        with:
-          config: ${{ github.workspace }}/.github/java-config.yml
+        shell: bash
+        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
 
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ steps.java-config.outputs['java-version'] }}
-          distribution: ${{ steps.java-config.outputs['distribution'] }}
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Checkout to ${{ github.event.inputs.branch_name }}
         uses: actions/checkout@v4

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -377,16 +377,14 @@ jobs:
           python-version: 3.9
 
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
-        id: java-config
-        with:
-          config: ${{ github.workspace }}/.github/java-config.yml
+        shell: bash
+        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
 
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ steps.java-config.outputs['java-version'] }}
-          distribution: ${{ steps.java-config.outputs['distribution'] }}
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Install .NET
         uses: actions/setup-dotnet@v3


### PR DESCRIPTION
Reverts change in https://github.com/hazelcast/client-compatibility-suites/pull/107, and updates original implementation to run in bash (not powershell) as per [the C++ client](https://github.com/hazelcast/hazelcast-cpp-client/blob/9ca294413ade65417d4d368dd6918a49179c3a58/.github/actions/build-test/windows/action.yml#L55) on Windows.