### PR TITLE
Fix `boost` installation script

### DIFF
--- a/KubernetesInternalClients/cpp/Dockerfile
+++ b/KubernetesInternalClients/cpp/Dockerfile
@@ -8,7 +8,7 @@ RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v3.19.0/cmak
     ./cmake-3.19.0-Linux-x86_64.sh --prefix=/usr/local/ --exclude-subdir && \
     rm cmake-3.19.0-Linux-x86_64.sh
 	
-RUN wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2 && tar xjf boost_1_76_0.tar.bz2 && rm boost_1_76_0.tar.bz2 && cd boost_1_76_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_76_0
+RUN wget --quiet https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2 && tar xjf boost_1_76_0.tar.bz2 && rm boost_1_76_0.tar.bz2 && cd boost_1_76_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_76_0
 
 ADD . .
 


### PR DESCRIPTION
Replicates fix in https://github.com/hazelcast/hazelcast-cpp-client/pull/1257 to fix [build failure](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15277137314).