### PR TITLE
Do not use deprecated `set-output` command

### DIFF
--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -27,7 +27,7 @@ jobs:
         
       - name: Set server matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_server_matrix.py )"
+        run: echo "{name}={matrix::$( python get_server_matrix.py )}" >> $GITHUB_OUTPUT
         
   test_client:
     needs: [setup_server_matrix]

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Set server matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_server_matrix.py )"
+        run: echo "{name}={matrix::$( python get_server_matrix.py )}" >> $GITHUB_OUTPUT
 
   test_client:
     needs: [setup_server_matrix]

--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -27,7 +27,7 @@ jobs:
         
       - name: Set server matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_server_matrix.py )"
+        run: echo "{name}={matrix::$( python get_server_matrix.py )}" >> $GITHUB_OUTPUT
         
   test_client:
     needs: [setup_server_matrix]

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set server matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_server_matrix.py )"
+        run: echo "{name}={matrix::$( python get_server_matrix.py )}" >> $GITHUB_OUTPUT
   test_client:
     needs: [setup_server_matrix]
     runs-on: ubuntu-latest

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set server matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_server_matrix.py )"
+        run: echo "{name}={matrix::$( python get_server_matrix.py )}" >> $GITHUB_OUTPUT
   test_client:
     needs: [setup_server_matrix]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Do not use deprecated `set-output` command. We get warnings in github action workflows as this:

Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I applied the recommended fix.