### PR TITLE
Update C++ client docker fedora version to 34 in sync with nightly builds

### DIFF
--- a/KubernetesInternalClients/cpp/Dockerfile
+++ b/KubernetesInternalClients/cpp/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:22
+FROM fedora:34
 
 RUN dnf groups install -y "Development Tools"
 RUN dnf install -y gcc-c++ tar wget bzip2 unzip cmake which


### PR DESCRIPTION
Updates C++ client docker fedora version to 34 in sync with nightly builds.

Without the update, we got invalid certificate problem during wget boost file download.

Also, adde retries for boost download.