### PR TITLE
Updated the deprecated `Upload image` step action 

### DIFF
--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -184,7 +184,7 @@ jobs:
       - name: Upload image
         uses: ishworkh/container-image-artifact-upload@v2.0.0
         with:
-          image: "hazelcast-cpp-client:test"
+         image: "hazelcast-cpp-client:test"
          
   create-go-image:
    runs-on: ubuntu-latest


### PR DESCRIPTION
Updated the deprecated `Upload image` step action with the recommended one.

Upload step worked with this PR  as seen [here](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15298504026/job/43033173454).