### PR TITLE
Remove the java client log copy step which fails builds DEX-433

### DIFF
--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -315,13 +315,6 @@ jobs:
             kubectl logs --tail=20 hazelcast-${{ matrix.client-language }}-client >> output-${{ matrix.client-language }}-deletepods.txt
             cat output-${{ matrix.client-language }}-deletepods.txt
             if [ $(grep -o 'Current map size:' output-${{ matrix.client-language }}-deletepods.txt | wc -l) != $"20" ]; then exit 1; fi
-            kubectl cp hazelcast-java-client:/log/hazelcast.log hazelcast.log
-
-      - name: Upload hazelcast logs
-        uses: actions/upload-artifact@v4
-        with: 
-          name: hazelcast.log
-          path: hazelcast.log
 
       - name: Logs
         if: always()


### PR DESCRIPTION
Removed the java client log copy step which fails build when we do not run java client. See https://github.com/hazelcast/client-compatibility-suites/actions/runs/15321849674/job/43107575868

Green build [here](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15322357227)