### PR TITLE
Fix externalised Java configuration on Windows

### DIFF
--- a/.github/workflows/cloud_csharp_client_test.yaml
+++ b/.github/workflows/cloud_csharp_client_test.yaml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.9
 
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
 
       - name: Install Java
         uses: actions/setup-java@v4

--- a/.github/workflows/cloud_go_client_test.yaml
+++ b/.github/workflows/cloud_go_client_test.yaml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.9
 
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
   
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/cloud_java_client_test.yaml
+++ b/.github/workflows/cloud_java_client_test.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/cloud_nodejs_client_test.yaml
+++ b/.github/workflows/cloud_nodejs_client_test.yaml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.9
 
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/cloud_python_client_test.yaml
+++ b/.github/workflows/cloud_python_client_test.yaml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.9
 
       - name: Read Java Config   
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Read Java Config
         shell: bash
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version: 14
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -145,7 +145,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -254,7 +254,7 @@ jobs:
         with:
           node-version: 14
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -368,7 +368,7 @@ jobs:
 
       - name: Read Java Config
         shell: bash
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -585,7 +585,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -705,7 +705,7 @@ jobs:
         run: |
           echo "HAZELCAST_ENTERPRISE_KEY=${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}" >> ${GITHUB_ENV}
       - name: Read Java Config
-        run: cat ${{ github.workspace }}/.github/java-config.env >> $GITHUB_ENV
+        run: cat ${GITHUB_WORKSPACE}/.github/java-config.env >> $GITHUB_ENV
       - name: Setup Java
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
The `java-config.env` file [cannot be read on Windows](https://github.com/hazelcast/client-compatibility-suites/pull/160#issuecomment-2999910444) due to a [GitHub issue](https://github.com/actions/runner/issues/2058) where file path slashes are not being properly resolved for the executing shell/runner.

Addressed using the suggested workaround - I've applied it everywhere, even where not strictly required, for consistency.

[Example execution](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15849813203).

Closes https://github.com/hazelcast/client-compatibility-suites/pull/168