### PR TITLE
Fix C++ `5.0`/`5.1` build failures [DI-556]

### DIFF
--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -93,7 +93,7 @@ jobs:
               -DCMAKE_BUILD_TYPE=Debug                                     \
               -DBUILD_SHARED_LIBS=ON                                       \
               -DWITH_OPENSSL=ON                                            \
-              -DBUILD_TESTS=ON                                             \
+              -DBUILD_TESTS=OFF                                            \
               -DBUILD_EXAMPLES=OFF
         working-directory: client
 

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -656,7 +656,7 @@ jobs:
               -DCMAKE_BUILD_TYPE=Debug                                     \
               -DBUILD_SHARED_LIBS=ON                                       \
               -DWITH_OPENSSL=ON                                            \
-              -DBUILD_TESTS=ON                                             \
+              -DBUILD_TESTS=OFF                                            \
               -DBUILD_EXAMPLES=OFF
         working-directory: tag
       - name: Test


### PR DESCRIPTION
The compatibility tests [fail for C++ `5.0`/`5.1`](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15851234939):
```HazelcastTests7.cpp:1591:5: error: ‘FIPS_mode_set’ was not declared in this scope```

This is caused by an incompatibility with the older unit test code against OpenSSL `v3`, which was addressed on the C++ client side in https://github.com/hazelcast/hazelcast-cpp-client/pull/1098

The environment obtains OpenSSL as a `gdb` dependency via `apt`, it's version is not static:
https://github.com/hazelcast/client-compatibility-suites/blob/8b735bf75002fff2b39f7fb7833c99d78352497e/.github/workflows/server_compatibility.yaml#L612
```
openssl version
OpenSSL 3.0.13 30 Jan 2024 (Library: OpenSSL 3.0.13 30 Jan 2024)
```

We don't actually _need_ to compile the C++ client unit tests for the purposes of the compatibility tests so the fix is simple - don't. This sidesteps the incompatibility completely.

[Example execution](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15851234939/job/44715069724) showing the _build_ passing.

Fixes: [DI-556](https://hazelcast.atlassian.net/browse/DI-556)

[DI-556]: https://hazelcast.atlassian.net/browse/DI-556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ