### PR TITLE
Fix older Go compatibility tests

### DIFF
--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -70,6 +70,15 @@ jobs:
           path: client
           ref: ${{ github.event.inputs.branch_name }}
 
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.inputs.organization_name }}/hazelcast-go-client
+          path: client-master
+          sparse-checkout: |
+            rc.sh
+          sparse-checkout-cone-mode: false
+
       - name: Copy certificates JAR to destination with the appropriate name
         run: |
           cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/client/hazelcast-enterprise-${{ matrix.version }}-tests.jar
@@ -79,12 +88,18 @@ jobs:
         with:
           hazelcast-version: ${{ matrix.version }}
 
+      - name: Start Remote Controller
+        env:
+          HZ_VERSION: ${{ matrix.version }}
+        run: |
+          ./rc.sh start
+        working-directory: client-master
+
       - name: Test
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}
           HZ_VERSION: ${{ matrix.version }}
           SSL_ENABLED: 1
         run: |
-          ./rc.sh start
           make test-all
         working-directory: client

--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -92,8 +92,8 @@ jobs:
         env:
           HZ_VERSION: ${{ matrix.version }}
         run: |
-          ./rc.sh start
-        working-directory: client-master
+          ../client-master/rc.sh start
+        working-directory: client
 
       - name: Test
         env:

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -759,8 +759,8 @@ jobs:
         env:
           HZ_VERSION: '${{ github.event.inputs.hz_version }}-SNAPSHOT'
         run: |
-          ./rc.sh start
-        working-directory: client-master
+          ../client-master/rc.sh start
+        working-directory: client
 
       - name: Test
         env:

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -718,7 +718,16 @@ jobs:
           repository: hazelcast/hazelcast-go-client
           path: client
           ref: ${{ matrix.client_tag }}
-          
+
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          repository: hazelcast/hazelcast-go-client
+          path: client-master
+          sparse-checkout: |
+            rc.sh
+          sparse-checkout-cone-mode: false
+
       - name: Download Hazelcast tests JAR
         uses: actions/download-artifact@v4
         with:
@@ -745,12 +754,18 @@ jobs:
         with:
           name: hazelcast-enterprise-tests
           path: client
-          
+
+      - name: Start Remote Controller
+        env:
+          HZ_VERSION: '${{ github.event.inputs.hz_version }}-SNAPSHOT'
+        run: |
+          ./rc.sh start
+        working-directory: client-master
+
       - name: Test
         env:
           HZ_VERSION: '${{ github.event.inputs.hz_version }}-SNAPSHOT'
           SSL_ENABLED: 1
         run: |
-          ./rc.sh start
           make test-all
         working-directory: client

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -757,7 +757,7 @@ jobs:
 
       - name: Start Remote Controller
         env:
-          HZ_VERSION: '${{ github.event.inputs.hz_version }}-SNAPSHOT'
+          HZ_VERSION: '${{ needs.upload_jars.outputs.hz_version }}'
         run: |
           ../client-master/rc.sh start
         working-directory: client


### PR DESCRIPTION
[The tests fail](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15851234939) because older versions do not include https://github.com/hazelcast/hazelcast-go-client/pull/966.

Addressed by using the `rc.sh` from `master` - we already do something similar for C#.

[Example execution](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15897506864).