### PR TITLE
Fix C++ `5.0`/`5.1` build failures [DI-556]

### DIFF
--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -85,15 +85,38 @@ jobs:
           sudo ./scripts/install-thrift.sh 0.13.0
         working-directory: client
           
+      - name: Detect Client Version
+        id: compute_client_version
+        run: |
+          client="${{ github.event.inputs.branch_name }}"
+          echo "CLIENT_VERSION=${client#v}" >> ${GITHUB_OUTPUT}
+
+      # https://github.com/madhead/semver-utils/releases/tag/v4.3.0
+      - uses: madhead/semver-utils@36d1e0ed361bd7b4b77665de8093092eaeabe6ba
+        id: client-version
+        with:
+          version: ${{ steps.compute_client_version.outputs.CLIENT_VERSION }}
+          compare-to: 5.2.0
+
+      - name: Determine if test with OpenSSL
+        id: with-openssl
+        run: |
+          if [[ "${{ steps.client-version.outputs.comparison-result }}" = "<" ]]; then
+            # Workaround lack of https://github.com/hazelcast/hazelcast-cpp-client/pull/1098
+            echo "WITH_OPENSSL=OFF" >> ${GITHUB_OUTPUT}
+          else
+            echo "WITH_OPENSSL=ON" >> ${GITHUB_OUTPUT}
+          fi
+
       - name: Build & Install
         env:
           BUILD_DIR: build
         run: |
-          ./scripts/build-unix.sh                                          \
-              -DCMAKE_BUILD_TYPE=Debug                                     \
-              -DBUILD_SHARED_LIBS=ON                                       \
-              -DWITH_OPENSSL=ON                                            \
-              -DBUILD_TESTS=ON                                             \
+          ./scripts/build-unix.sh                                           \
+              -DCMAKE_BUILD_TYPE=Debug                                      \
+              -DBUILD_SHARED_LIBS=ON                                        \
+              -DWITH_OPENSSL=${{ steps.with-openssl.outputs.WITH_OPENSSL }} \
+              -DBUILD_TESTS=ON                                              \
               -DBUILD_EXAMPLES=OFF
         working-directory: client
 

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -648,15 +648,39 @@ jobs:
         with:
           name: hazelcast-enterprise-tests
           path: tag
+
+      - name: Detect Client Version
+        id: compute_client_version
+        run: |
+          client="${{ matrix.client_tag }}"
+          echo "CLIENT_VERSION=${client#v}" >> ${GITHUB_OUTPUT}
+
+      # https://github.com/madhead/semver-utils/releases/tag/v4.3.0
+      - uses: madhead/semver-utils@36d1e0ed361bd7b4b77665de8093092eaeabe6ba
+        id: client-version
+        with:
+          version: ${{ steps.compute_client_version.outputs.CLIENT_VERSION }}
+          compare-to: 5.2.0
+
+      - name: Determine if test with OpenSSL
+        id: with-openssl
+        run: |
+          if [[ "${{ steps.client-version.outputs.comparison-result }}" = "<" ]]; then
+            # Workaround lack of https://github.com/hazelcast/hazelcast-cpp-client/pull/1098
+            echo "WITH_OPENSSL=OFF" >> ${GITHUB_OUTPUT}
+          else
+            echo "WITH_OPENSSL=ON" >> ${GITHUB_OUTPUT}
+          fi
+
       - name: Build & Install
         env:
           BUILD_DIR: build
         run: |
-          ./scripts/build-unix.sh                                          \
-              -DCMAKE_BUILD_TYPE=Debug                                     \
-              -DBUILD_SHARED_LIBS=ON                                       \
-              -DWITH_OPENSSL=ON                                            \
-              -DBUILD_TESTS=ON                                             \
+          ./scripts/build-unix.sh                                           \
+              -DCMAKE_BUILD_TYPE=Debug                                      \
+              -DBUILD_SHARED_LIBS=ON                                        \
+              -DWITH_OPENSSL=${{ steps.with-openssl.outputs.WITH_OPENSSL }} \
+              -DBUILD_TESTS=ON                                              \
               -DBUILD_EXAMPLES=OFF
         working-directory: tag
       - name: Test


### PR DESCRIPTION
The compatibility tests [fail for C++ `5.0`/`5.1`](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15851234939):
```HazelcastTests7.cpp:1591:5: error: ‘FIPS_mode_set’ was not declared in this scope```

This is caused by an incompatibility with the older unit test code against OpenSSL `v3`, which was addressed on the C++ client side in https://github.com/hazelcast/hazelcast-cpp-client/pull/1098

The environment obtains OpenSSL as a `gdb` dependency via `apt`, it's version is not static:
https://github.com/hazelcast/client-compatibility-suites/blob/8b735bf75002fff2b39f7fb7833c99d78352497e/.github/workflows/server_compatibility.yaml#L612
```
openssl version
OpenSSL 3.0.13 30 Jan 2024 (Library: OpenSSL 3.0.13 30 Jan 2024)
```

Fixed by disabling the SSL tests in C++ clients <5.2.

[Example execution](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15922496200/job/44914212891).

Fixes: [DI-556](https://hazelcast.atlassian.net/browse/DI-556)