### PR TITLE
Make `server_compatibility.yaml` inputs boolean

### DIFF
--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -675,7 +675,6 @@ jobs:
           sudo sh -c "echo '1' > /proc/sys/kernel/core_uses_pid"
           ./scripts/test-unix.sh
         working-directory: tag        
-
   setup_go_client_matrix:
     name: Setup the Go client test matrix
     if: ${{ inputs.run_go }}


### PR DESCRIPTION
The action uses magic input strings to determine which clients to test:
![image](https://github.com/user-attachments/assets/1153056f-7e79-46c1-99ca-6cb6fdfb2b38)

Which makes repeatedly executing an alternate test suite tedious.

Updated to to use `boolean`s:
![image](https://github.com/user-attachments/assets/5a3b5583-d154-4b87-ba3a-47f29f2e4074)

[Example execution showing C++ selected](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15973338298).