### PR TITLE
Fix Python compatibility tests due to paging predicate error

### DIFF
--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -95,11 +95,19 @@ jobs:
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.kind }} --use-simple-server
+      - name: Convert major.minor version to semver
+        id: generate-semver
+        run: |
+          VERSION="${{ github.event.inputs.branch_name }}"
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+            VERSION="${VERSION}.0"
+          fi
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
       # https://github.com/madhead/semver-utils/releases/tag/v4.3.0
       - uses: madhead/semver-utils@36d1e0ed361bd7b4b77665de8093092eaeabe6ba
         id: client-version
         with:
-          version: ${{ github.event.inputs.branch_name }}
+          version: ${{ steps.generate-semver.outputs.version }}
           compare-to: 5.5.0
       - name: Run tests
         run: |

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -98,6 +98,8 @@ jobs:
       - name: Convert major.minor version to semver
         id: generate-semver
         run: |
+          # `semver-utils` expects a fully qualified semver, but some older Python clients were major.minor (e.g. `v5.0`) which was unsupported
+          # In those cases, convert major.minor (e.g. `v5.0`) -> major.minor.patch (e.g. `v.5.0.0`)
           VERSION="${{ github.event.inputs.branch_name }}"
           if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+$ ]]; then
             VERSION="${VERSION}.0"

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -95,11 +95,20 @@ jobs:
         env:
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets[steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET] }}
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.kind }} --use-simple-server
-      - name: Run non-enterprise tests
-        if: ${{ matrix.kind == 'os' }}
-        run: pytest -m 'not enterprise' tests/integration/backward_compatible
-        working-directory: master
-      - name: Run all tests
-        if: ${{ matrix.kind == 'enterprise' }}
-        run: pytest tests/integration/backward_compatible
-        working-directory: master
+      # https://github.com/madhead/semver-utils/releases/tag/v4.3.0
+      - uses: madhead/semver-utils@36d1e0ed361bd7b4b77665de8093092eaeabe6ba
+        id: client-version
+        with:
+          version: ${{ github.event.inputs.branch_name }}
+          compare-to: 5.5.0
+      - name: Run tests
+        run: |
+          args=()
+          if [ "${{ matrix.kind }}" = "os" ]; then
+            args+=(-m "not enterprise")
+          fi
+          if [[ "${{ steps.client-version.outputs.comparison-result }}" = "<" ]]; then
+            # Workaround https://github.com/hazelcast/hazelcast-python-client/issues/666 by skipping those tests
+            args+=(--ignore tests/integration/backward_compatible/predicate_test.py)
+          fi
+          pytest tests/integration/backward_compatible "${args[@]}"

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -210,13 +210,23 @@ jobs:
           path: jars
       - name: Start RC
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.server_kind }} --use-simple-server
-      - name: Run non-enterprise tests
-        if: ${{ matrix.server_kind == 'os' }}
-        run: pytest -m 'not enterprise' tests/integration/backward_compatible
-        working-directory: master
-      - name: Run all tests
-        if: ${{ matrix.server_kind == 'enterprise' }}
-        run: pytest tests/integration/backward_compatible
+      # https://github.com/madhead/semver-utils/releases/tag/v4.3.0
+      - uses: madhead/semver-utils@36d1e0ed361bd7b4b77665de8093092eaeabe6ba
+        id: client-version
+        with:
+          version: ${{ matrix.client_tag }}
+          compare-to: 5.5.0
+      - name: Run tests
+        run: |
+          args=()
+          if [ "${{ matrix.server_kind }}" = "os" ]; then
+            args+=(-m "not enterprise")
+          fi
+          if [[ "${{ steps.client-version.outputs.comparison-result }}" = "<" ]]; then
+            # Workaround https://github.com/hazelcast/hazelcast-python-client/issues/666 by skipping those tests
+            args+=(--ignore tests/integration/backward_compatible/predicate_test.py)
+          fi
+          pytest tests/integration/backward_compatible "${args[@]}"
         working-directory: master
   setup_nodejs_client_matrix:
     name: Setup the Node.js client test matrix

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -213,6 +213,8 @@ jobs:
       - name: Convert major.minor version to semver
         id: generate-semver
         run: |
+          # `semver-utils` expects a fully qualified semver, but some older Python clients were major.minor (e.g. `v5.0`) which was unsupported
+          # In those cases, convert major.minor (e.g. `v5.0`) -> major.minor.patch (e.g. `v.5.0.0`)
           VERSION="${{ matrix.client_tag }}"
           if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+$ ]]; then
             VERSION="${VERSION}.0"

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -210,11 +210,19 @@ jobs:
           path: jars
       - name: Start RC
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.server_kind }} --use-simple-server
+      - name: Convert major.minor version to semver
+        id: generate-semver
+        run: |
+          VERSION="${{ matrix.client_tag }}"
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+            VERSION="${VERSION}.0"
+          fi
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
       # https://github.com/madhead/semver-utils/releases/tag/v4.3.0
       - uses: madhead/semver-utils@36d1e0ed361bd7b4b77665de8093092eaeabe6ba
         id: client-version
         with:
-          version: ${{ matrix.client_tag }}
+          version: ${{ steps.generate-semver.outputs.version }}
           compare-to: 5.5.0
       - name: Run tests
         run: |


### PR DESCRIPTION
The [tests are failing](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15993342471) due to a known issue in [older versions](https://github.com/hazelcast/hazelcast-python-client/issues/666).

We should ignore those tests in the older versions as we know they won't pass and don't indicate any _new_ issues.

Changes:
- ignore `predicate_test` for <`5.5`
- merge `Run non-enterprise tests` & `Run all tests` into a single step

[Slack discussion](https://hazelcast.slack.com/archives/C092T6Q0MA8/p1751282784324389).

[Example execution](https://github.com/hazelcast/client-compatibility-suites/actions/runs/16003219803).