### PR TITLE
Avoid deprecated `set-output` command

### DIFF
--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -116,13 +116,13 @@ jobs:
         echo "EXTERNAL_IP=${EXTERNAL_IP}" >> $GITHUB_ENV
     - name: Set output of external-ip
       id: external-ip
-      run: echo "external-ip=${{env.EXTERNAL_IP}}" >> ${GITHUB_OUTPUT}
+      run: echo "external-ip=${{ env.EXTERNAL_IP }}" >> ${GITHUB_OUTPUT}
     - name: Set output of gke_zone  
       id: gke_zone
-      run: echo "gke_zone=${{env.GKE_ZONE}}" >> ${GITHUB_OUTPUT}
+      run: echo "gke_zone=${{ env.GKE_ZONE }}" >> ${GITHUB_OUTPUT}
     - name: Set output of cluster_name  
       id: cluster_name
-      run: echo "cluster_name=${{env.clusterName}}" >> ${GITHUB_OUTPUT}
+      run: echo "cluster_name=${{ env.clusterName }}" >> ${GITHUB_OUTPUT}
         
   run_go:
     name: Run Go compatibility test

--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -116,13 +116,13 @@ jobs:
         echo "EXTERNAL_IP=${EXTERNAL_IP}" >> $GITHUB_ENV
     - name: Set output of external-ip
       id: external-ip
-      run: echo "::set-output name=external-ip::${{ env.EXTERNAL_IP }}"
+      run: echo "external-ip=${{env.EXTERNAL_IP}}" >> ${GITHUB_OUTPUT}
     - name: Set output of gke_zone  
       id: gke_zone
-      run: echo "::set-output name=gke_zone::${{env.GKE_ZONE}}"
+      run: echo "gke_zone=${{env.GKE_ZONE}}" >> ${GITHUB_OUTPUT}
     - name: Set output of cluster_name  
       id: cluster_name
-      run: echo "::set-output name=cluster_name::${{env.clusterName}}"
+      run: echo "cluster_name=${{env.clusterName}}" >> ${GITHUB_OUTPUT}
         
   run_go:
     name: Run Go compatibility test

--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -176,11 +176,11 @@ jobs:
 
     - name: Set which client will be run
       id: set-matrix
-      run: echo "matrix=$( python set_which_client_run.py \
-       --nodejs ${{ github.event.inputs.nodejs_run }} \ 
-       --go ${{ github.event.inputs.go_run }} \
-       --cpp ${{ github.event.inputs.cpp_run }} \
-       --csharp ${{ github.event.inputs.csharp_run }} \
+      run: echo "matrix=$( python set_which_client_run.py
+       --nodejs ${{ github.event.inputs.nodejs_run }}
+       --go ${{ github.event.inputs.go_run }}
+       --cpp ${{ github.event.inputs.cpp_run }}
+       --csharp ${{ github.event.inputs.csharp_run }}
        --python ${{ github.event.inputs.python_run }})" >> ${GITHUB_OUTPUT}
          
   run-tests:

--- a/.github/workflows/KubernetesInternalClients.yaml
+++ b/.github/workflows/KubernetesInternalClients.yaml
@@ -176,12 +176,12 @@ jobs:
 
     - name: Set which client will be run
       id: set-matrix
-      run: echo "::set-output name=matrix::$( python set_which_client_run.py
-       --nodejs ${{ github.event.inputs.nodejs_run }}
-       --go ${{ github.event.inputs.go_run }}
-       --cpp ${{ github.event.inputs.cpp_run }}
-       --csharp ${{ github.event.inputs.csharp_run }}
-       --python ${{ github.event.inputs.python_run }})"
+      run: echo "matrix=$( python set_which_client_run.py \
+       --nodejs ${{ github.event.inputs.nodejs_run }} \ 
+       --go ${{ github.event.inputs.go_run }} \
+       --cpp ${{ github.event.inputs.cpp_run }} \
+       --csharp ${{ github.event.inputs.csharp_run }} \
+       --python ${{ github.event.inputs.python_run }})" >> ${GITHUB_OUTPUT}
          
   run-tests:
     name: Run kubernetes compatibility test

--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -27,7 +27,7 @@ jobs:
         
       - name: Set server matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_server_matrix.py )"
+        run: echo "matrix=$( python get_server_matrix.py )" >> ${GITHUB_OUTPUT}
         
   test_client:
     needs: [setup_server_matrix]

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Set server matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_server_matrix.py )"
+        run: echo "matrix=$( python get_server_matrix.py )" >> ${GITHUB_OUTPUT}
 
   test_client:
     needs: [setup_server_matrix]

--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -27,7 +27,7 @@ jobs:
         
       - name: Set server matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_server_matrix.py )"
+        run: echo "matrix=$( python get_server_matrix.py )" >> ${GITHUB_OUTPUT}
         
   test_client:
     needs: [setup_server_matrix]

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set server matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_server_matrix.py )"
+        run: echo "matrix=$( python get_server_matrix.py )" >> ${GITHUB_OUTPUT}
   test_client:
     needs: [setup_server_matrix]
     runs-on: ubuntu-latest

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set server matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_server_matrix.py )"
+        run: echo "matrix=$( python get_server_matrix.py )" >> ${GITHUB_OUTPUT}
   test_client:
     needs: [setup_server_matrix]
     runs-on: ubuntu-latest

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -127,7 +127,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set client matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_client_matrix.py --client py --option tag --use-latest-patch-versions )"
+        run: echo "matrix=$( python get_client_matrix.py --client py --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
   test_python_clients:
     needs: [ upload_jars, setup_python_client_matrix ]
     runs-on: ubuntu-latest
@@ -233,7 +233,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set client matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_client_matrix.py --client node --option tag --use-latest-patch-versions )"
+        run: echo "matrix=$( python get_client_matrix.py --client node --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
   test_nodejs_clients:
     needs: [ upload_jars, setup_nodejs_client_matrix ]
     runs-on: ubuntu-latest
@@ -348,7 +348,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set client matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_client_matrix.py --client cs --option tag --use-latest-patch-versions )"
+        run: echo "matrix=$( python get_client_matrix.py --client cs --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
   test_csharp_clients:
     needs: [ upload_jars,  setup_csharp_client_matrix ]
     runs-on: windows-latest
@@ -566,7 +566,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set client matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_client_matrix.py --client cpp --option tag --use-latest-patch-versions )"
+        run: echo "matrix=$( python get_client_matrix.py --client cpp --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
   test_cpp_clients:
     needs: [ upload_jars, setup_cpp_client_matrix ]
     runs-on: ubuntu-latest
@@ -690,7 +690,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set client matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::$( python get_client_matrix.py --client go --option tag --use-latest-patch-versions )"       
+        run: echo "matrix=$( python get_client_matrix.py --client go --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
   test_go_client:
     needs: [upload_jars, setup_go_client_matrix]
     runs-on: ubuntu-latest


### PR DESCRIPTION
[A warning is logged during the build](https://github.com/hazelcast/client-compatibility-suites/actions/runs/16020766406):
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Updated to resolve.

[Example execution](https://github.com/hazelcast/client-compatibility-suites/actions/runs/16021764635).

Closes: https://github.com/hazelcast/client-compatibility-suites/pull/163