### PR TITLE
Fix Node.js Enterprise tests

### DIFF
--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -320,6 +320,9 @@ jobs:
           path: jars
       - name: Start RC
         run: python start_rc.py --rc-version '0.8-SNAPSHOT' --jars jars --server-kind ${{ matrix.server_kind }}
+      - name: Update certificates
+        if: ${{ matrix.server_kind == 'enterprise' }}
+        run: unzip -p jars/hazelcast-enterprise-${{ needs.upload_jars.outputs.hz_version }}-tests.jar com/hazelcast/nio/ssl/letsencrypt.jks > master/test/integration/backward_compatible/parallel/ssl/keystore.jks
       - name: Run all tests
         run: node node_modules/mocha/bin/mocha --recursive test/integration/backward_compatible
         working-directory: master


### PR DESCRIPTION
The [NodeJS tests are failing](https://github.com/hazelcast/client-compatibility-suites/actions/runs/16021764635/job/45200929188):
> WARN at ConnectionManager: Error during initial connection to 127.0.0.1:34513 Error: certificate has expired

Same issue (and solution - albeit slightly reworked) as https://github.com/hazelcast/hazelcast-nodejs-client/pull/1535

[Example execution](https://github.com/hazelcast/client-compatibility-suites/actions/runs/16051905507).