### PR TITLE
Fix C# tests post `set-output` changes [DI-565]

### DIFF
--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -329,7 +329,7 @@ jobs:
   setup_csharp_client_matrix:
     name: Setup the Csharp client test matrix
     if: ${{ inputs.run_csharp }}
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:


### PR DESCRIPTION
Since https://github.com/hazelcast/client-compatibility-suites/pull/178, the C# tests have been failing to start.

This is because the updated command is for `bash`, but the executing shell for the `setup_csharp_client_matrix` job is implicitly `pwsh`.

We don't actually _need_ to use Windows for the setup step, so rather than rewriting the command it's better to use Ubuntu which is less GitHub Actions resource consuming.

We _already_ do this in `csharp_client_compatibility`.

[Example execution](https://github.com/hazelcast/client-compatibility-suites/actions/runs/16140232371).

Fixes: [DI-565](https://hazelcast.atlassian.net/browse/DI-565)