### PR TITLE
Get Hazelcast Enteprise License Key from AWS [DI-588]

### DIFF
--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -79,12 +79,25 @@ jobs:
         --network=${{env.GCP_NETWORK}} 
         sleep 30
 
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: 'us-east-1'
+
+    - name: Get Secrets
+      uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      with:
+        secret-ids: |
+          HZ_LICENSE_KEY,CN/HZ_LICENSE_KEY
+
     - name: Deploy Hazelcast cluster
       run: |-
         helm repo add hazelcast https://hazelcast-charts.s3.amazonaws.com/
         helm repo update
         helm install operator hazelcast/hazelcast-platform-operator --set installCRDs=true
-        kubectl create secret generic hazelcast-license-key --from-literal=license-key=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}
+        kubectl create secret generic hazelcast-license-key --from-literal=license-key=${HZ_LICENSE_KEY}
         cat <<EOF | kubectl apply -f -
         apiVersion: hazelcast.com/v1alpha1
         kind: Hazelcast


### PR DESCRIPTION
We should try to use a single secrets manager where possible.

Note, updating `get-enterprise-license` is _non-trivial_ and yet is the only place left to update and must remain as a technical debt.

[Slack discussion](https://hazelcast.slack.com/archives/CE8GYK5QX/p1754657344019809?thread_ts=1754650773.398089&cid=CE8GYK5QX)