### PR TITLE
Make Maven output quieter

### DIFF
--- a/.github/workflows/cloud_java_client_test.yaml
+++ b/.github/workflows/cloud_java_client_test.yaml
@@ -38,5 +38,5 @@ jobs:
           API_SECRET: ${{ secrets.APISECRET_VIRIDIAN }}
           HZ_VERSION: ${{ github.event.inputs.hzVersion }}
         run: |
-          mvn clean test "-Dhazelcast-version=${{ github.event.inputs.java_client_version }}"
+          mvn clean test "-Dhazelcast-version=${{ github.event.inputs.java_client_version }}" --batch-mode --no-transfer-progress
         working-directory: HazelcastCloudTests/javahazelcastcloudtests

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -43,6 +43,8 @@ jobs:
     outputs:
       hz_version: ${{ steps.compute_hz_version.outputs.hz_version }}
       hazelcast_enterprise_key_secret: ${{ steps.get-enterprise-license.outputs.HAZELCAST_ENTERPRISE_KEY_SECRET }}
+    env:
+      MAVEN_ARGS: '--batch-mode --no-transfer-progress'
     steps:
       - name: Checkout to scripts
         uses: actions/checkout@v4


### PR DESCRIPTION
The download progress of Maven makes the [logs unnecesarily long](https://github.com/hazelcast/client-compatibility-suites/actions/runs/16911559150/job/47914338479).

Instead we should use the same argument [we do elsewhere](https://github.com/hazelcast/hazelcast-code-samples/blob/cd159d7718a20cb63b3bc7ec9a022dc8a17e94be/.github/workflows/builder.yaml#L41-L47) to customise this.