### PR TITLE
Relocate `hazelcast-remote-controller` [DI-639]

### DIFF
--- a/HazelcastCloudTests/javahazelcastcloudtests/pom.xml
+++ b/HazelcastCloudTests/javahazelcastcloudtests/pom.xml
@@ -82,14 +82,6 @@
     </dependencies>
     <repositories>
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <id>private-repository</id>
             <name>Hazelcast Private Repository</name>
             <url>https://repository.hazelcast.com/snapshot/</url>

--- a/go-rc.sh
+++ b/go-rc.sh
@@ -74,7 +74,7 @@ download () {
 downloadRC () {
   local jar_path="hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar"
   local artifact="com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION}"
-  download "$SNAPSHOT_REPO" "$jar_path" "$artifact"
+  download "$ENTERPRISE_RELEASE_REPO" "$jar_path" "$artifact"
   classpath="$classpath:$jar_path"
 }
 
@@ -175,7 +175,7 @@ HAZELCAST_TEST_VERSION=${HZ_VERSION}
 HAZELCAST_ENTERPRISE_VERSION=${HZ_VERSION}
 HAZELCAST_RC_VERSION="0.8-SNAPSHOT"
 SNAPSHOT_REPO="https://oss.sonatype.org/content/repositories/snapshots"
-RELEASE_REPO="http://repo1.maven.apache.org/maven2"
+RELEASE_REPO="https://repo.maven.apache.org/maven2"
 ENTERPRISE_RELEASE_REPO="https://repository.hazelcast.com/release/"
 ENTERPRISE_SNAPSHOT_REPO="https://repository.hazelcast.com/snapshot/"
 

--- a/start_rc.py
+++ b/start_rc.py
@@ -7,8 +7,7 @@ from contextlib import closing
 from os import path
 
 from util import (
-    SNAPSHOT_REPO,
-    RELEASE_REPO,
+    ENTERPRISE_SNAPSHOT_REPO,
     download_via_maven,
     IS_ON_WINDOWS,
     ServerKind,
@@ -61,12 +60,7 @@ def parse_args() -> argparse.Namespace:
 def start_rc(
     rc_version: str, dst_folder: str, use_simple_server: bool, server_kind: ServerKind
 ) -> None:
-    if rc_version.upper().endswith("-SNAPSHOT"):
-        rc_repo = SNAPSHOT_REPO
-    else:
-        rc_repo = RELEASE_REPO
-
-    download_via_maven(rc_repo, "hazelcast-remote-controller", rc_version, dst_folder)
+    download_via_maven(ENTERPRISE_SNAPSHOT_REPO, "hazelcast-remote-controller", rc_version, dst_folder)
     class_path = path.join(dst_folder, "*")
 
     args = [

--- a/start_remote_controller.py
+++ b/start_remote_controller.py
@@ -7,7 +7,7 @@ from os.path import isfile
 SERVER_VERSION = "5.0"
 RC_VERSION = "0.8-SNAPSHOT"
 
-RELEASE_REPO = "https://repo1.maven.apache.org/maven2"
+RELEASE_REPO = "https://repo.maven.apache.org/maven2"
 ENTERPRISE_RELEASE_REPO = "https://repository.hazelcast.com/release/"
 SNAPSHOT_REPO = "https://oss.sonatype.org/content/repositories/snapshots"
 ENTERPRISE_SNAPSHOT_REPO = "https://repository.hazelcast.com/snapshot/"
@@ -80,7 +80,7 @@ def download_if_necessary(repo, artifact_id, version, is_test_artifact=False):
 def start_rc(use_simple_server: bool, stdout=None, stderr=None):
     artifacts = []
 
-    rc = download_if_necessary(RC_REPO, "hazelcast-remote-controller", RC_VERSION)
+    rc = download_if_necessary(ENTERPRISE_SNAPSHOT_REPO, "hazelcast-remote-controller", RC_VERSION)
     tests = download_if_necessary(REPO, "hazelcast", SERVER_VERSION, True)
     sql = download_if_necessary(REPO, "hazelcast-sql", SERVER_VERSION)
 

--- a/util.py
+++ b/util.py
@@ -49,7 +49,7 @@ HAZELCAST_SERVERS = "https://raw.githubusercontent.com/hazelcast/rel-scripts/mas
 
 CLIENT_HEADER = "======= %s Client\n---\n(.*?)\n---\n==="
 
-RELEASE_REPO = "http://repo1.maven.apache.org/maven2"
+RELEASE_REPO = "https://repo.maven.apache.org/maven2"
 ENTERPRISE_RELEASE_REPO = "https://repository.hazelcast.com/release/"
 SNAPSHOT_REPO = "https://oss.sonatype.org/content/repositories/snapshots"
 ENTERPRISE_SNAPSHOT_REPO = "https://repository.hazelcast.com/snapshot/"


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-remote-controller/pull/75, `hazelcast-remote-controller` is deployed to a different repository to address build issues. Update the paths to suit.

Also:
- updated Maven central URL as per https://github.com/hazelcast/hazelcast-mono/pull/4897
- updated Maven central URL to use `HTTPS`, as `HTTP` is [no longer supported](https://maven.apache.org/docs/3.8.1/release-notes.html).

Fixes: [DI-639](https://hazelcast.atlassian.net/browse/DI-639)