### PR TITLE
Remove unused `get_client_matrix` options

### DIFF
--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Set client matrix
         id: set-matrix
-        run: echo "matrix=$( python get_client_matrix.py --client py --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
+        run: echo "matrix=$( python get_client_matrix.py --client py )" >> ${GITHUB_OUTPUT}
 
   test_python_clients:
     needs: [ upload_jars, setup_python_client_matrix ]
@@ -296,7 +296,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Set client matrix
         id: set-matrix
-        run: echo "matrix=$( python get_client_matrix.py --client node --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
+        run: echo "matrix=$( python get_client_matrix.py --client node )" >> ${GITHUB_OUTPUT}
   test_nodejs_clients:
     needs: [ upload_jars, setup_nodejs_client_matrix ]
     runs-on: ubuntu-latest
@@ -404,7 +404,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Set client matrix
         id: set-matrix
-        run: echo "matrix=$( python get_client_matrix.py --client cs --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
+        run: echo "matrix=$( python get_client_matrix.py --client cs )" >> ${GITHUB_OUTPUT}
   test_csharp_clients:
     needs: [ upload_jars,  setup_csharp_client_matrix ]
     runs-on: windows-latest
@@ -626,7 +626,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Set client matrix
         id: set-matrix
-        run: echo "matrix=$( python get_client_matrix.py --client cpp --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
+        run: echo "matrix=$( python get_client_matrix.py --client cpp )" >> ${GITHUB_OUTPUT}
   test_cpp_clients:
     needs: [ upload_jars, setup_cpp_client_matrix ]
     runs-on: ubuntu-latest
@@ -703,7 +703,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Set client matrix
         id: set-matrix
-        run: echo "matrix=$( python get_client_matrix.py --client go --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
+        run: echo "matrix=$( python get_client_matrix.py --client go )" >> ${GITHUB_OUTPUT}
   test_go_client:
     needs: [upload_jars, setup_go_client_matrix]
     runs-on: ubuntu-latest

--- a/get_client_matrix.py
+++ b/get_client_matrix.py
@@ -7,9 +7,8 @@ from util import (
     StableReleaseFilter,
     SupportedReleaseFilter,
     MajorVersionFilter,
-    MatrixOptionKind,
     Version,
-    get_option_from_release,
+    get_tag,
     get_latest_patch_releases,
 )
 
@@ -29,33 +28,12 @@ def parse_args() -> argparse.Namespace:
         help="Client type",
     )
 
-    parser.add_argument(
-        "--option",
-        dest="option",
-        action="store",
-        type=str,
-        choices=[kind.name.lower() for kind in MatrixOptionKind],
-        required=True,
-        help="Matrix option type",
-    )
-
-    parser.add_argument(
-        "--use-latest-patch-versions",
-        dest="use_latest_patch_versions",
-        action="store_true",
-        default=False,
-        required=False,
-        help="Use only the latest patch versions",
-    )
-
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
     client_kind = ClientKind[args.client.upper()]
-    matrix_option_kind = MatrixOptionKind[args.option.upper()]
-    use_latest_patch_versions = args.use_latest_patch_versions
 
     if client_kind == ClientKind.GO:
         filtered_major_version = [1]
@@ -79,10 +57,9 @@ if __name__ == "__main__":
     client_release_parser = ClientReleaseParser(client_kind, filters)
     releases = client_release_parser.get_all_releases()
 
-    if use_latest_patch_versions:
-        releases = get_latest_patch_releases(releases)
+    releases = get_latest_patch_releases(releases)
 
     options = [
-        get_option_from_release(release, matrix_option_kind) for release in releases
+        get_tag(release) for release in releases
     ]
     print(json.dumps(options))

--- a/util.py
+++ b/util.py
@@ -74,11 +74,6 @@ class ClientKind(Enum):
     GO = "Go"
 
 
-class MatrixOptionKind(Enum):
-    TAG = 0
-    VERSION = 1
-
-
 class ServerKind(Enum):
     OS = 0
     ENTERPRISE = 1
@@ -306,16 +301,6 @@ def get_tag(release: Release) -> str:
     return tail
 
 
-def get_version(release: Release) -> str:
-    return release.version.version_str
-
-
-MATRIX_OPTION_KIND_TO_GETTER: Dict[MatrixOptionKind, Callable[[Release], str]] = {
-    MatrixOptionKind.TAG: get_tag,
-    MatrixOptionKind.VERSION: get_version,
-}
-
-
 def get_latest_patch_releases(releases: List[Release]) -> List[Release]:
     major_to_minor_to_latest_patch: DefaultDict[
         int, DefaultDict[int, Release]
@@ -335,10 +320,6 @@ def get_latest_patch_releases(releases: List[Release]) -> List[Release]:
             latest_patch_releases.append(latest_patch)
 
     return latest_patch_releases
-
-
-def get_option_from_release(release: Release, option: MatrixOptionKind) -> str:
-    return MATRIX_OPTION_KIND_TO_GETTER[option](release)
 
 
 class DownloadFailedError(Exception):


### PR DESCRIPTION
`get_client_matrix` is always called with:
- `--option tag`
- `--use-latest-patch-versions`

As such, we should simplify the code by:
- making these the default
- removing the other option implementations

[Example execution](https://github.com/hazelcast/client-compatibility-suites/actions/runs/24182544335).