### PR TITLE
Centralise `setup-[client/server]-matrix` jobs

### DIFF
--- a/.github/workflows/cpp_client_compatibility.yaml
+++ b/.github/workflows/cpp_client_compatibility.yaml
@@ -13,21 +13,7 @@ on:
         default: master
 jobs:
   setup_server_matrix:
-    name: Setup the server test matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.9
-      - name: Checkout to scripts
-        uses: actions/checkout@v6
-        
-      - name: Set server matrix
-        id: set-matrix
-        run: echo "matrix=$( python get_server_matrix.py )" >> ${GITHUB_OUTPUT}
+    uses: ./.github/workflows/get-server-matrix.yaml
         
   test_client:
     needs: [setup_server_matrix]

--- a/.github/workflows/csharp_client_compatibility.yaml
+++ b/.github/workflows/csharp_client_compatibility.yaml
@@ -14,22 +14,7 @@ on:
 
 jobs:
   setup_server_matrix:
-    name: Setup the server test matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.9
-
-      - name: Checkout to scripts
-        uses: actions/checkout@v6
-
-      - name: Set server matrix
-        id: set-matrix
-        run: echo "matrix=$( python get_server_matrix.py )" >> ${GITHUB_OUTPUT}
+    uses: ./.github/workflows/get-server-matrix.yaml
 
   test_client:
     needs: [setup_server_matrix]

--- a/.github/workflows/get-client-matrix.yaml
+++ b/.github/workflows/get-client-matrix.yaml
@@ -1,0 +1,32 @@
+name: Get client matrix
+
+on:
+  workflow_call:
+    inputs:
+      client:
+        type: string
+        required: true
+    outputs:
+      matrix:
+        value: ${{ jobs.setup_client_matrix.outputs.matrix }}
+
+jobs:
+  setup_client_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout to scripts
+        uses: actions/checkout@v6
+      - name: Set client matrix
+        id: set-matrix
+        run: |
+          echo "matrix=$(
+            python \
+            get_client_matrix.py \
+              --client ${CLIENT} \
+              --option tag \
+              --use-latest-patch-versions \
+          )" >> ${GITHUB_OUTPUT}
+        env:
+          CLIENT: ${{ inputs.client }}

--- a/.github/workflows/get-client-matrix.yaml
+++ b/.github/workflows/get-client-matrix.yaml
@@ -25,8 +25,6 @@ jobs:
             python \
             get_client_matrix.py \
               --client ${CLIENT} \
-              --option tag \
-              --use-latest-patch-versions \
           )" >> ${GITHUB_OUTPUT}
         env:
           CLIENT: ${{ inputs.client }}

--- a/.github/workflows/get-server-matrix.yaml
+++ b/.github/workflows/get-server-matrix.yaml
@@ -1,0 +1,24 @@
+name: Get server matrix
+
+on:
+  workflow_call:
+    outputs:
+      matrix:
+        value: ${{ jobs.setup_server_matrix.outputs.matrix }}
+
+jobs:
+  setup_server_matrix:
+    name: Setup the server test matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout to scripts
+        uses: actions/checkout@v6
+      - name: Set server matrix
+        id: set-matrix
+        run: |
+          echo "matrix=$(
+            python \
+            get_server_matrix.py \
+          )" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/go_client_compatibility.yaml
+++ b/.github/workflows/go_client_compatibility.yaml
@@ -13,21 +13,7 @@ on:
         default: master
 jobs:
   setup_server_matrix:
-    name: Setup the server test matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.9
-      - name: Checkout to scripts
-        uses: actions/checkout@v6
-        
-      - name: Set server matrix
-        id: set-matrix
-        run: echo "matrix=$( python get_server_matrix.py )" >> ${GITHUB_OUTPUT}
+    uses: ./.github/workflows/get-server-matrix.yaml
         
   test_client:
     needs: [setup_server_matrix]

--- a/.github/workflows/nodejs_client_compatibility.yaml
+++ b/.github/workflows/nodejs_client_compatibility.yaml
@@ -14,22 +14,7 @@ on:
 
 jobs:
   setup_server_matrix:
-    name: Setup the server test matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.9
-
-      - name: Checkout to scripts
-        uses: actions/checkout@v6
-
-      - name: Set server matrix
-        id: set-matrix
-        run: echo "matrix=$( python get_server_matrix.py )" >> ${GITHUB_OUTPUT}
+    uses: ./.github/workflows/get-server-matrix.yaml
 
   test_client:
     needs: [setup_server_matrix]

--- a/.github/workflows/python_client_compatibility.yaml
+++ b/.github/workflows/python_client_compatibility.yaml
@@ -14,20 +14,8 @@ on:
 
 jobs:
   setup_server_matrix:
-    name: Setup the server test matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-      - name: Checkout to scripts
-        uses: actions/checkout@v6
-      - name: Set server matrix
-        id: set-matrix
-        run: echo "matrix=$( python get_server_matrix.py )" >> ${GITHUB_OUTPUT}
+    uses: ./.github/workflows/get-server-matrix.yaml
+    
   test_client:
     needs: [setup_server_matrix]
     runs-on: ubuntu-latest

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -122,21 +122,9 @@ jobs:
   setup_python_client_matrix:
     name: Setup the Python client test matrix
     if: ${{ inputs.run_python }}
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-
-      - name: Checkout to scripts
-        uses: actions/checkout@v6
-
-      - name: Set client matrix
-        id: set-matrix
-        run: echo "matrix=$( python get_client_matrix.py --client py --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
+    uses: ./.github/workflows/get-client-matrix.yaml
+    with:
+      client: py
 
   test_python_clients:
     needs: [ upload_jars, setup_python_client_matrix ]
@@ -284,19 +272,9 @@ jobs:
   setup_nodejs_client_matrix:
     name: Setup the Node.js client test matrix
     if: ${{ inputs.run_nodejs }}
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.9
-      - name: Checkout to scripts
-        uses: actions/checkout@v6
-      - name: Set client matrix
-        id: set-matrix
-        run: echo "matrix=$( python get_client_matrix.py --client node --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
+    uses: ./.github/workflows/get-client-matrix.yaml
+    with:
+      client: node
   test_nodejs_clients:
     needs: [ upload_jars, setup_nodejs_client_matrix ]
     runs-on: ubuntu-latest
@@ -392,19 +370,9 @@ jobs:
   setup_csharp_client_matrix:
     name: Setup the Csharp client test matrix
     if: ${{ inputs.run_csharp }}
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.9
-      - name: Checkout to scripts
-        uses: actions/checkout@v6
-      - name: Set client matrix
-        id: set-matrix
-        run: echo "matrix=$( python get_client_matrix.py --client cs --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
+    uses: ./.github/workflows/get-client-matrix.yaml
+    with:
+      client: cs
   test_csharp_clients:
     needs: [ upload_jars,  setup_csharp_client_matrix ]
     runs-on: windows-latest
@@ -614,19 +582,9 @@ jobs:
   setup_cpp_client_matrix:
     name: Setup the Cpp client test matrix
     if: ${{ inputs.run_cpp }}
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.9
-      - name: Checkout to scripts
-        uses: actions/checkout@v6
-      - name: Set client matrix
-        id: set-matrix
-        run: echo "matrix=$( python get_client_matrix.py --client cpp --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
+    uses: ./.github/workflows/get-client-matrix.yaml
+    with:
+      client: cpp
   test_cpp_clients:
     needs: [ upload_jars, setup_cpp_client_matrix ]
     runs-on: ubuntu-latest
@@ -691,19 +649,9 @@ jobs:
   setup_go_client_matrix:
     name: Setup the Go client test matrix
     if: ${{ inputs.run_go }}
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.9
-      - name: Checkout to scripts
-        uses: actions/checkout@v6
-      - name: Set client matrix
-        id: set-matrix
-        run: echo "matrix=$( python get_client_matrix.py --client go --option tag --use-latest-patch-versions )" >> ${GITHUB_OUTPUT}
+    uses: ./.github/workflows/get-client-matrix.yaml
+    with:
+      client: go
   test_go_client:
     needs: [upload_jars, setup_go_client_matrix]
     runs-on: ubuntu-latest


### PR DESCRIPTION
We should avoid repeating boilerplate and call centralised action(s).

Of note - different workflows used different version of Python in conjunction with `setup-python`. The runner comes bundled with a version of Python sufficient to run this simple script - no installation was even required, removed.

[Example execution](https://github.com/hazelcast/client-compatibility-suites/actions/runs/24183921052) (purely to show test execution matrixes resolving correctly).