### PR TITLE
Remove hardcoded supported server version

### DIFF
--- a/.github/workflows/get-server-matrix.yaml
+++ b/.github/workflows/get-server-matrix.yaml
@@ -13,6 +13,10 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - id: get-maintenance-versions
+        uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions@master
+      - id: calculate-minimum-supported-version
+        run: echo "VERSION=$(echo '${{ steps.get-maintenance-versions.outputs.versions }}' | jq '.[0]')" >> ${GITHUB_OUTPUT}
       - name: Checkout to scripts
         uses: actions/checkout@v6
       - name: Set server matrix
@@ -21,4 +25,5 @@ jobs:
           echo "matrix=$(
             python \
             get_server_matrix.py \
+              --minimum-version ${{ steps.calculate-minimum-supported-version.outputs.VERSION }} \
           )" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -221,28 +221,28 @@ jobs:
           compare-to: 5.5.0
 
       - name: Download Hazelcast tests JAR
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-tests
           path: jars
 
       - name: Download Hazelcast SQL JAR (if exists)
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-sql
           path: jars
 
       - name: Download Hazelcast JAR
         if: ${{ matrix.server_kind == 'os' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast
           path: jars
 
       - name: Download Hazelcast Enterprise JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-enterprise
           path: jars
@@ -293,7 +293,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v2
         with:
           node-version: 14
       - name: Read Java Config
@@ -331,31 +331,31 @@ jobs:
           cp -a $GITHUB_WORKSPACE/tag/lib $GITHUB_WORKSPACE/master/lib
           cp -a $GITHUB_WORKSPACE/tag/package.json $GITHUB_WORKSPACE/master/package.json
       - name: Download Hazelcast tests JAR
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-tests
           path: jars
       - name: Download Hazelcast SQL JAR (if exists)
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-sql
           path: jars
       - name: Download Hazelcast JAR
         if: ${{ matrix.server_kind == 'os' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast
           path: jars
       - name: Download Hazelcast Enterprise JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-enterprise
           path: jars
       - name: Download Hazelcast Enterprise tests JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-enterprise-tests
           path: jars
@@ -434,35 +434,35 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Download Hazelcast tests JAR
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-tests
           path: tag/temp/lib
 
       - name: Download Hazelcast SQL JAR (if exists)
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-sql
           path: tag/temp/lib
 
       - name: Download Hazelcast JAR
         if: ${{ matrix.server_kind == 'os' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast
           path: tag/temp/lib
 
       - name: Download Hazelcast Enterprise JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-enterprise
           path: tag/temp/lib
 
       - name: Download Hazelcast Enterprise tests JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-enterprise-tests
           path: tag/temp/lib
@@ -612,31 +612,31 @@ jobs:
           rm -rf tag/scripts
           cp -R master/scripts tag/
       - name: Download Hazelcast tests JAR
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-tests
           path: tag
       - name: Download Hazelcast SQL JAR (if exists)
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-sql
           path: tag
       - name: Download Hazelcast JAR
         if: ${{ matrix.server_kind == 'os' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast
           path: tag
       - name: Download Hazelcast Enterprise JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-enterprise
           path: tag
       - name: Download Hazelcast Enterprise tests JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-enterprise-tests
           path: tag
@@ -690,28 +690,28 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Download Hazelcast tests JAR
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-tests
           path: client
       - name: Download Hazelcast JAR
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast
           path: client
       - name: Download Hazelcast SQL JAR (if exists)
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-sql
           path: client
       - name: Download Hazelcast Enterprise JAR
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-enterprise
           path: client
       - name: Download Hazelcast Enterprise tests JAR
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: hazelcast-enterprise-tests
           path: client

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -221,28 +221,28 @@ jobs:
           compare-to: 5.5.0
 
       - name: Download Hazelcast tests JAR
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-tests
           path: jars
 
       - name: Download Hazelcast SQL JAR (if exists)
         continue-on-error: true
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-sql
           path: jars
 
       - name: Download Hazelcast JAR
         if: ${{ matrix.server_kind == 'os' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast
           path: jars
 
       - name: Download Hazelcast Enterprise JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-enterprise
           path: jars
@@ -293,7 +293,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: 14
       - name: Read Java Config
@@ -331,31 +331,31 @@ jobs:
           cp -a $GITHUB_WORKSPACE/tag/lib $GITHUB_WORKSPACE/master/lib
           cp -a $GITHUB_WORKSPACE/tag/package.json $GITHUB_WORKSPACE/master/package.json
       - name: Download Hazelcast tests JAR
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-tests
           path: jars
       - name: Download Hazelcast SQL JAR (if exists)
         continue-on-error: true
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-sql
           path: jars
       - name: Download Hazelcast JAR
         if: ${{ matrix.server_kind == 'os' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast
           path: jars
       - name: Download Hazelcast Enterprise JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-enterprise
           path: jars
       - name: Download Hazelcast Enterprise tests JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-enterprise-tests
           path: jars
@@ -434,35 +434,35 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Download Hazelcast tests JAR
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-tests
           path: tag/temp/lib
 
       - name: Download Hazelcast SQL JAR (if exists)
         continue-on-error: true
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-sql
           path: tag/temp/lib
 
       - name: Download Hazelcast JAR
         if: ${{ matrix.server_kind == 'os' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast
           path: tag/temp/lib
 
       - name: Download Hazelcast Enterprise JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-enterprise
           path: tag/temp/lib
 
       - name: Download Hazelcast Enterprise tests JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-enterprise-tests
           path: tag/temp/lib
@@ -612,31 +612,31 @@ jobs:
           rm -rf tag/scripts
           cp -R master/scripts tag/
       - name: Download Hazelcast tests JAR
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-tests
           path: tag
       - name: Download Hazelcast SQL JAR (if exists)
         continue-on-error: true
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-sql
           path: tag
       - name: Download Hazelcast JAR
         if: ${{ matrix.server_kind == 'os' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast
           path: tag
       - name: Download Hazelcast Enterprise JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-enterprise
           path: tag
       - name: Download Hazelcast Enterprise tests JAR
         if: ${{ matrix.server_kind == 'enterprise' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-enterprise-tests
           path: tag
@@ -690,28 +690,28 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Download Hazelcast tests JAR
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-tests
           path: client
       - name: Download Hazelcast JAR
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast
           path: client
       - name: Download Hazelcast SQL JAR (if exists)
         continue-on-error: true
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-sql
           path: client
       - name: Download Hazelcast Enterprise JAR
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-enterprise
           path: client
       - name: Download Hazelcast Enterprise tests JAR
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: hazelcast-enterprise-tests
           path: client

--- a/get_server_matrix.py
+++ b/get_server_matrix.py
@@ -5,10 +5,8 @@ from typing import List
 from util import (
     MajorMinorVersionFilter,
     ServerReleaseParser,
-    SupportedReleaseFilter,
     get_latest_patch_releases,
-    ReleaseFilter,
-    Version
+    ReleaseFilter
 )
 
 
@@ -17,13 +15,22 @@ def parse_args() -> argparse.Namespace:
         description="Returns the server version matrix as a JSON array"
     )
 
+    parser.add_argument(
+        "--minimum-version",
+        dest="minimum_version",
+        action="store",
+        type=str,
+        required=True,
+        help="Minimum server version",
+    )
+
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
-    unsupported_versions = []
-    filters: List[ReleaseFilter] = [MajorMinorVersionFilter((5, 2)), SupportedReleaseFilter(unsupported_versions)]
+    minimum_major_version, minimum_minor_version = map(int, args.minimum_version.split("."))
+    filters: List[ReleaseFilter] = [MajorMinorVersionFilter((minimum_major_version, minimum_minor_version))]
     server_release_parser = ServerReleaseParser(filters)
     releases = server_release_parser.get_all_releases()
     latest_patch_releases = get_latest_patch_releases(releases)

--- a/util.py
+++ b/util.py
@@ -44,7 +44,6 @@ TAG_ATTRIBUTE = "Github"
 IMDG_CLIENTS = (
     "https://raw.githubusercontent.com/hazelcast/rel-scripts/master/imdg-clients.txt"
 )
-IMDG_SERVERS = "https://raw.githubusercontent.com/hazelcast/rel-scripts/master/imdg-enterprise.txt"
 HAZELCAST_SERVERS = "https://raw.githubusercontent.com/hazelcast/rel-scripts/master/hazelcast-enterprise.txt"
 
 CLIENT_HEADER = "======= %s Client\n---\n(.*?)\n---\n==="
@@ -236,21 +235,21 @@ class AbstractReleaseParser(ABC):
 
 class ServerReleaseParser(AbstractReleaseParser):
     def get_source_urls(self) -> List[str]:
-        return [IMDG_SERVERS, HAZELCAST_SERVERS]
+        return [HAZELCAST_SERVERS]
 
     def parse_raw_data(self, raw_data: str) -> List[Release]:
         stable_match = re.search(CURRENT_STABLE_SERVER_PATTERN, raw_data)
         if not stable_match:
             raise ValueError(
                 "Cannot find a match on the server data "
-                "located at %s for the current stable version." % IMDG_SERVERS
+                "located at %s for the current stable version." % HAZELCAST_SERVERS
             )
 
         previous_match = re.search(PREVIOUS_STABLE_SERVER_PATTERN, raw_data)
         if not previous_match:
             raise ValueError(
                 "Cannot find a match on the server data "
-                "located at %s for the previous stable versions." % IMDG_SERVERS
+                "located at %s for the previous stable versions." % HAZELCAST_SERVERS
             )
 
         all_releases = []


### PR DESCRIPTION
The supported server version is hardcoded to `5.2` since https://github.com/hazelcast/client-compatibility-suites/pull/198.

However, `5.2` is out of support - rather than updating it, it would be better if it used the [_existing_ centralised list of supported versions](https://github.com/hazelcast/hazelcast/blob/master/.github/actions/get-supported-maintenance-versions/action.yml) as used elsewhere.

This implicitly changes the minimum supported version (at time of writing) to `5.4`.

Additionally, removed metadata of IMDG (i.e. `4.x`) servers as they will never be used if our minimum version is `5.x`.

[Example execution](https://github.com/hazelcast/client-compatibility-suites/actions/runs/24185358682).