### PR TITLE
Replace explicit AWS token with tokenless-OIDC authentication [DI-706]

### DIFF
--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -47,6 +47,8 @@ jobs:
       cluster_name: ${{steps.cluster_name.outputs.cluster_name}}
       GKE_ZONE: ${{steps.gke_zone.outputs.gke_zone}}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     env:
       GCP_NETWORK: operator-test-network
     
@@ -86,8 +88,7 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v6
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
         aws-region: 'us-east-1'
 
     - name: Get Secrets


### PR DESCRIPTION
See:
- https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws
- [ADR](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/6645022721/ADR-00089-+Type+2+-Migrate+GitHub+Actions+to+use+tokenless+OIDC+authentication)
- [reference `hazelcast-docker` implementation](https://github.com/hazelcast/hazelcast-docker/pull/1197)

Fixes: [DI-706](https://hazelcast.atlassian.net/browse/DI-706)

[DI-706]: https://hazelcast.atlassian.net/browse/DI-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ