### PR TITLE
Rescope AWS ARN from `secret` to `var`

### DIFF
--- a/.github/workflows/KubernetesExternalClients.yaml
+++ b/.github/workflows/KubernetesExternalClients.yaml
@@ -88,7 +88,7 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v6
       with:
-        role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+        role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
         aws-region: 'us-east-1'
 
     - name: Get Secrets

--- a/.github/workflows/server_compatibility.yaml
+++ b/.github/workflows/server_compatibility.yaml
@@ -527,7 +527,7 @@ jobs:
       - uses: hazelcast/docker-actions/get-jfrog-credentials@master
         id: jfrog
         with:
-          aws-role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           jfrog-oidc-provider-name: ${{ github.repository_owner }}-snapshot-internal
 
       - name: Run non-enterprise tests


### PR DESCRIPTION
The name of the role isn't a `secret`, so storing at such means it's masked logs etc which makes debugging difficult. More specifically, authentication is handled via [OIDC](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws), on it's own the role does nothing.

Instead, it should be rescoped as a `var`.