### PR TITLE
Update boost for cpp release [HZ-5456]

### DIFF
--- a/.github/actions/cpp-compatibility-test/action.yml
+++ b/.github/actions/cpp-compatibility-test/action.yml
@@ -30,7 +30,7 @@ runs:
     - name: Install Boost
       shell: bash
       run: |
-        sudo ./scripts/install-boost.sh 1.76.0
+        sudo ./scripts/install-boost.sh 1.83.0
       working-directory: ${{ inputs.working-directory }}
         
     - name: Install Thrift


### PR DESCRIPTION
as we dont more support old version of boost start using 1.83.0 as min required 

as https://github.com/hazelcast/client-compatibility-suites/actions/runs/26748563613/job/78830347423#logs had failed we need to bump boost version